### PR TITLE
Apply database migrations and check static files

### DIFF
--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -248,7 +248,11 @@
         {% if messages %}
             {% for message in messages %}
                 <div class="alert alert-{{ message.tags }}-medical alert-dismissible fade show" role="alert">
-                    <i class="fas fa-{{ message.tags == 'error' and 'exclamation-triangle' or 'info-circle' }} me-2"></i>
+                    {% if message.tags == 'error' %}
+                        <i class="fas fa-exclamation-triangle me-2"></i>
+                    {% else %}
+                        <i class="fas fa-info-circle me-2"></i>
+                    {% endif %}
                     {{ message }}
                     <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
                 </div>


### PR DESCRIPTION
Fixes TemplateSyntaxError in login.html by replacing Python-style conditional with Django template tags. Django templates do not support Python's `and`/`or` operators directly within variable expressions, requiring the use of `{% if %}` blocks for conditional logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-de42658a-2f03-45a6-ae3a-6dc2015d7d31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de42658a-2f03-45a6-ae3a-6dc2015d7d31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

