### PR TITLE
Install development dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ scikit-image==0.22.0
 matplotlib==3.8.2
 
 # AI and machine learning
-numpy==1.24.3
+numpy==1.26.2
 scipy==1.11.4
 pandas==2.1.4
 torch==2.1.1
@@ -49,3 +49,7 @@ PyJWT==2.8.0
 python-magic==0.4.27
 requests==2.31.0
 urllib3==2.1.0
+
+# Essential build tools (for Python 3.12 compatibility)
+setuptools>=65.0.0
+wheel>=0.37.0


### PR DESCRIPTION
Update numpy and add build tools to fix `distutils` error on Python 3.12.

The `numpy==1.24.3` version is incompatible with Python 3.12 due to its dependency on the `distutils` module, which was removed in Python 3.12. Updating `numpy` to `1.26.2` and explicitly adding `setuptools` and `wheel` resolves this build dependency issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2be40fb-e1b6-4eb2-b1db-fc4df3ca81e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2be40fb-e1b6-4eb2-b1db-fc4df3ca81e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

