### PR TITLE
Fix user notifications attribute error

### DIFF
--- a/noctis_pro/asgi.py
+++ b/noctis_pro/asgi.py
@@ -9,22 +9,30 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
 
 import os
 from django.core.asgi import get_asgi_application
-from channels.routing import ProtocolTypeRouter, URLRouter
-from channels.auth import AuthMiddlewareStack
-from channels.security.websocket import AllowedHostsOriginValidator
-import chat.routing
-import notifications.routing
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'noctis_pro.settings')
 
-application = ProtocolTypeRouter({
-    "http": get_asgi_application(),
-    "websocket": AllowedHostsOriginValidator(
-        AuthMiddlewareStack(
-            URLRouter([
-                *chat.routing.websocket_urlpatterns,
-                *notifications.routing.websocket_urlpatterns,
-            ])
-        )
-    ),
-})
+# For now, use simple HTTP ASGI application until channels are properly configured
+django_asgi_app = get_asgi_application()
+
+try:
+    from channels.routing import ProtocolTypeRouter, URLRouter
+    from channels.auth import AuthMiddlewareStack
+    from channels.security.websocket import AllowedHostsOriginValidator
+    import chat.routing
+    import notifications.routing
+
+    application = ProtocolTypeRouter({
+        "http": django_asgi_app,
+        "websocket": AllowedHostsOriginValidator(
+            AuthMiddlewareStack(
+                URLRouter([
+                    *chat.routing.websocket_urlpatterns,
+                    *notifications.routing.websocket_urlpatterns,
+                ])
+            )
+        ),
+    })
+except ImportError:
+    # Fallback to simple HTTP application if channels dependencies are not available
+    application = django_asgi_app

--- a/noctis_pro/settings.py
+++ b/noctis_pro/settings.py
@@ -50,7 +50,7 @@ INSTALLED_APPS = [
     # 'reports',  # Temporarily disabled
     'admin_panel',
     # 'chat',  # Temporarily disabled
-    # 'notifications',  # Temporarily disabled
+    'notifications',  # Re-enabled to fix User.notifications relationship
     'ai_analysis',
 ]
 

--- a/noctis_pro/urls.py
+++ b/noctis_pro/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
     # path('reports/', include('reports.urls')),  # Temporarily disabled
     path('admin-panel/', include('admin_panel.urls')),
     # path('chat/', include('chat.urls')),  # Temporarily disabled
-    # path('notifications/', include('notifications.urls')),  # Temporarily disabled
+    path('notifications/', include('notifications.urls')),  # Re-enabled to fix template URLs
     path('ai/', include('ai_analysis.urls')),
 ]
 

--- a/worklist/views.py
+++ b/worklist/views.py
@@ -45,7 +45,11 @@ def dashboard(request):
     recent_studies = studies.order_by('-upload_date')[:10]
     
     # Get unread notifications count
-    unread_notifications_count = user.notifications.filter(is_read=False).count()
+    try:
+        unread_notifications_count = user.notifications.filter(is_read=False).count()
+    except AttributeError:
+        # Handle case where notifications app is not enabled or relationship doesn't exist
+        unread_notifications_count = 0
     
     context = {
         'user': user,


### PR DESCRIPTION
Re-enables the notifications app and its URLs, and adds robust error handling to fix `AttributeError: 'User' object has no attribute 'notifications'`.

The `notifications` app was disabled in `INSTALLED_APPS` and its URLs were commented out, preventing Django from recognizing the `User.notifications` reverse relationship. This PR enables the app and its URLs, and adds `try-except` blocks in `worklist/views.py` and `noctis_pro/asgi.py` for graceful degradation if the app or its dependencies are not available.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d8b00ce-0be2-45fe-86d0-9e2e479df3b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d8b00ce-0be2-45fe-86d0-9e2e479df3b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

