### PR TITLE
Fix missing upload_study url pattern

### DIFF
--- a/worklist/urls.py
+++ b/worklist/urls.py
@@ -7,6 +7,7 @@ app_name = 'worklist'
 urlpatterns = [
     # Main worklist interfaces
     path('', views.dashboard, name='dashboard'),
+    path('upload/', views.upload_study, name='upload_study'),
     path('studies/', views.study_list, name='study_list'),
     path('study/<int:study_id>/', views.study_detail, name='study_detail'),
     


### PR DESCRIPTION
Add missing URL pattern for `upload_study` to resolve `NoReverseMatch` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-557b3b13-7c30-4eb8-8652-a4f4de646357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-557b3b13-7c30-4eb8-8652-a4f4de646357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

