### PR TITLE
Fix missing api_studies url pattern

### DIFF
--- a/worklist/urls.py
+++ b/worklist/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('api/attachment/<int:attachment_id>/search/', api_attachment_search, name='api_attachment_search'),
     
     # API endpoints
+    path('api/studies/', views.api_studies, name='api_studies'),
     path('api/search-studies/', views.api_search_studies, name='api_search_studies'),
     path('api/study/<int:study_id>/update-status/', views.api_update_study_status, name='api_update_study_status'),
 ]


### PR DESCRIPTION
Add missing URL pattern for `api_studies` to resolve `NoReverseMatch` error on the worklist dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0644010-746c-455f-bd73-5c3cd7037690">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0644010-746c-455f-bd73-5c3cd7037690">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

