### PR TITLE
Fix unread count url reverse match

### DIFF
--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -6,4 +6,5 @@ app_name = 'notifications'
 urlpatterns = [
     path('', views.notification_list, name='notification_list'),
     path('api/notifications/', views.api_notifications, name='api_notifications'),
+    path('api/unread-count/', views.api_unread_count, name='api_unread_count'),
 ]

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse
+from .models import Notification
 
 @login_required
 def notification_list(request):
@@ -11,3 +12,10 @@ def notification_list(request):
 def api_notifications(request):
     """API endpoint for notifications"""
     return JsonResponse({'notifications': []})
+
+@login_required
+def api_unread_count(request):
+    """API endpoint to get unread notifications count"""
+    user = request.user
+    unread_count = Notification.objects.filter(recipient=user, is_read=False).count()
+    return JsonResponse({'count': unread_count})


### PR DESCRIPTION
Add `api_unread_count` view and URL pattern to resolve `NoReverseMatch` error in the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9704727-57f6-4f4d-b3fe-ff546bb2e9e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9704727-57f6-4f4d-b3fe-ff546bb2e9e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

