### PR TITLE
Resolve pyqt5-tools dependency conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,4 +52,4 @@ urllib3==2.1.0
 
 # PyQt5 for standalone desktop applications
 PyQt5==5.15.10
-PyQt5-tools==5.15.9.3.3
+qt5-tools==5.15.2.1.3


### PR DESCRIPTION
Replace `PyQt5-tools` with `qt5-tools` in `requirements.txt` to resolve an unresolvable dependency on `pyqt5-plugins`.

---
<a href="https://cursor.com/background-agent?bcId=bc-76214bb9-a043-484c-a497-9a0b1ba446aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76214bb9-a043-484c-a497-9a0b1ba446aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

