### PR TITLE
Resolve pyqt5 and pyqt5-tools dependency conflict

### DIFF
--- a/QT_DESIGNER_ALTERNATIVES.md
+++ b/QT_DESIGNER_ALTERNATIVES.md
@@ -1,0 +1,62 @@
+# PyQt5 Designer Alternatives
+
+Due to dependency conflicts with `pyqt5-tools`, here are alternative ways to get Qt Designer for your PyQt5 development:
+
+## Option 1: System Package Installation (Recommended)
+```bash
+# For Ubuntu/Debian:
+sudo apt update
+sudo apt install qttools5-dev-tools
+
+# This installs Qt Designer system-wide
+# You can launch it with:
+designer
+```
+
+## Option 2: Install Qt Creator with Designer
+```bash
+# Ubuntu/Debian:
+sudo apt install qtcreator
+
+# This includes Qt Designer as part of Qt Creator
+```
+
+## Option 3: Manual Qt Installation
+1. Download Qt from the official website: https://www.qt.io/download
+2. Install the complete Qt toolkit which includes Designer
+3. Add the Qt bin directory to your PATH
+
+## Option 4: Using PyQt5Designer (if available)
+```bash
+# This is sometimes available as a separate package:
+pip install PyQt5Designer
+```
+
+## Option 5: Alternative UI Design Tools
+- **Qt Design Studio** - Official Qt tool for UI design
+- **GUI Editors** - Various third-party PyQt5 GUI builders
+- **Hand-code UI** - Create layouts programmatically
+
+## Current Requirements Status
+Your `requirements.txt` now includes only:
+```
+PyQt5==5.15.9
+```
+
+This provides the core PyQt5 functionality without the problematic tool dependencies.
+
+## Verification
+To verify PyQt5 works correctly, create a simple test:
+```python
+import sys
+from PyQt5.QtWidgets import QApplication, QWidget, QLabel
+
+app = QApplication(sys.argv)
+window = QWidget()
+window.setWindowTitle('PyQt5 Test')
+window.setGeometry(100, 100, 300, 200)
+label = QLabel('PyQt5 is working!', window)
+label.move(100, 80)
+window.show()
+sys.exit(app.exec_())
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,4 +52,5 @@ urllib3==2.1.0
 
 # PyQt5 for standalone desktop applications
 PyQt5==5.15.9
-pyqt5-tools==5.15.9.3.3
+# Note: pyqt5-tools removed due to dependency conflicts
+# For Qt Designer, consider installing system packages or using alternatives

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,5 +51,5 @@ requests==2.31.0
 urllib3==2.1.0
 
 # PyQt5 for standalone desktop applications
-PyQt5==5.15.10
-qt5-tools==5.15.2.1.3
+PyQt5==5.15.9
+pyqt5-tools==5.15.9.3.3


### PR DESCRIPTION
Remove `pyqt5-tools` from `requirements.txt` and add a guide for Qt Designer alternatives to resolve dependency conflicts.

The `pyqt5-tools` package caused persistent dependency conflicts with `PyQt5` due to its specific `pyqt5-plugins` version requirements, which were not satisfiable. Removing it allows core PyQt5 installation while providing clear instructions for obtaining Qt Designer separately.

---
<a href="https://cursor.com/background-agent?bcId=bc-9992253d-be61-4a5f-95d9-c1c7ddca97c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9992253d-be61-4a5f-95d9-c1c7ddca97c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

