### PR TITLE
Fix uncaught getcookie reference error

### DIFF
--- a/templates/dicom_viewer/standalone_viewer.html
+++ b/templates/dicom_viewer/standalone_viewer.html
@@ -472,6 +472,9 @@
 
 <!-- Hidden File Input -->
 <input type="file" id="fileInput" multiple accept=".dcm,.dicom,application/dicom" style="display: none;">
+
+<!-- CSRF Token for AJAX requests -->
+{% csrf_token %}
 {% endblock %}
 
 {% block extra_js %}
@@ -488,6 +491,33 @@ let playInterval = null;
 let zoomLevel = 1;
 let panOffset = { x: 0, y: 0 };
 let windowLevel = { width: 400, center: 40 };
+
+// CSRF Token utility functions
+function getCookie(name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        const cookies = document.cookie.split(';');
+        for (let i = 0; i < cookies.length; i++) {
+            const cookie = cookies[i].trim();
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
+function getCsrfToken() {
+    // Try to get from Django template first
+    const csrfInput = document.querySelector('[name=csrfmiddlewaretoken]');
+    if (csrfInput) {
+        return csrfInput.value;
+    }
+    // Fallback to cookie
+    return getCookie('csrftoken');
+}
 
 // Initialize the viewer
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
Adds `getCookie` and `getCsrfToken` functions and a CSRF token to `standalone_viewer.html` to fix `getCookie is not defined` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-a501f421-3fcc-421e-9689-2e99a7d31668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a501f421-3fcc-421e-9689-2e99a7d31668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

