### PR TITLE
Handle favicon not found error

### DIFF
--- a/noctis_pro/urls.py
+++ b/noctis_pro/urls.py
@@ -19,6 +19,7 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 from django.shortcuts import redirect
+from django.http import HttpResponse
 
 def home_redirect(request):
     """Redirect home page to login or dashboard based on authentication"""
@@ -27,8 +28,13 @@ def home_redirect(request):
         return redirect('worklist:dashboard')
     return redirect('accounts:login')
 
+def favicon_view(request):
+    """Return an empty response for favicon requests to avoid 404 errors"""
+    return HttpResponse(status=204)  # No content
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('favicon.ico', favicon_view, name='favicon'),
     path('', home_redirect, name='home'),
     path('', include('accounts.urls')),
     path('worklist/', include('worklist.urls')),


### PR DESCRIPTION
Add a URL pattern to handle `favicon.ico` requests and prevent 404 errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-838b1936-3b48-4a6f-93d9-21c2459b7d66">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-838b1936-3b48-4a6f-93d9-21c2459b7d66">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

