### PR TITLE
Implement standalone viewer from pasted code

### DIFF
--- a/templates/dicom_viewer/standalone_viewer.html
+++ b/templates/dicom_viewer/standalone_viewer.html
@@ -4,228 +4,443 @@
 
 {% block extra_css %}
 <style>
+    /* Main viewer container */
     .viewer-container {
-        background: var(--dark-bg);
+        background: #1a1a1a;
         height: 100vh;
         overflow: hidden;
         display: flex;
         flex-direction: column;
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     }
 
+    /* Header bar */
     .viewer-header {
-        background: var(--gradient-primary);
-        border-bottom: 1px solid var(--border-color);
-        padding: 0.75rem 1rem;
+        background: linear-gradient(135deg, #2c2c2c 0%, #1f1f1f 100%);
+        border-bottom: 1px solid #404040;
+        padding: 12px 20px;
         display: flex;
         justify-content: space-between;
         align-items: center;
         z-index: 100;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     }
 
     .viewer-title {
         display: flex;
         align-items: center;
-        color: var(--text-primary);
-        gap: 1rem;
+        color: #ffffff;
+        gap: 12px;
     }
 
     .viewer-title h3 {
         margin: 0;
         font-weight: 600;
+        font-size: 18px;
+    }
+
+    .viewer-title i {
+        font-size: 24px;
+        color: #0078d4;
     }
 
     .header-actions {
         display: flex;
         align-items: center;
-        gap: 1rem;
+        gap: 12px;
     }
 
-    .load-file-btn {
-        background: var(--gradient-accent);
+    .header-btn {
+        background: #0078d4;
         border: none;
-        border-radius: 8px;
+        border-radius: 6px;
         color: white;
-        padding: 8px 16px;
+        padding: 10px 16px;
         font-weight: 500;
         cursor: pointer;
-        transition: all 0.3s ease;
+        transition: all 0.2s ease;
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: 8px;
+        font-size: 14px;
     }
 
-    .load-file-btn:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(14, 165, 233, 0.3);
+    .header-btn:hover {
+        background: #106ebe;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(16, 120, 190, 0.4);
     }
 
+    .header-btn.secondary {
+        background: #404040;
+        border: 1px solid #555;
+    }
+
+    .header-btn.secondary:hover {
+        background: #4a4a4a;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    }
+
+    /* Main layout */
     .viewer-main {
         display: flex;
         flex: 1;
         overflow: hidden;
     }
 
-    .sidebar {
-        background: var(--card-bg);
-        border-right: 1px solid var(--border-color);
-        width: 300px;
-        padding: 1rem;
-        overflow-y: auto;
-        transition: width 0.3s ease;
-    }
-
-    .sidebar.collapsed {
-        width: 60px;
-    }
-
-    .sidebar-toggle {
-        position: absolute;
-        top: 50%;
-        right: -15px;
-        background: var(--accent-color);
-        border: none;
-        border-radius: 50%;
-        width: 30px;
-        height: 30px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        cursor: pointer;
-        z-index: 10;
-        transform: translateY(-50%);
-        transition: all 0.3s ease;
-    }
-
-    .sidebar-toggle:hover {
-        background: var(--secondary-color);
-        transform: translateY(-50%) scale(1.1);
-    }
-
-    .viewer-content {
-        flex: 1;
+    /* Left toolbar */
+    .toolbar {
+        background: #2a2a2a;
+        border-right: 1px solid #404040;
+        width: 80px;
+        padding: 10px 5px;
         display: flex;
         flex-direction: column;
-        background: #000;
+        gap: 8px;
+        align-items: center;
     }
 
-    .viewport-grid {
+    .tool-btn {
+        background: #363636;
+        border: none;
+        border-radius: 8px;
+        color: #ffffff;
+        width: 70px;
+        height: 60px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        font-size: 11px;
+        font-weight: 500;
+    }
+
+    .tool-btn:hover {
+        background: #404040;
+        transform: translateY(-1px);
+    }
+
+    .tool-btn.active {
+        background: #0078d4;
+        box-shadow: 0 0 12px rgba(0, 120, 212, 0.4);
+    }
+
+    .tool-btn i {
+        font-size: 20px;
+        margin-bottom: 2px;
+    }
+
+    /* Center viewport */
+    .viewport-container {
         flex: 1;
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        grid-template-rows: 1fr 1fr;
-        gap: 2px;
-        padding: 2px;
-        background: var(--border-color);
+        background: #000000;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .patient-info-bar {
+        background: #333333;
+        border-bottom: 1px solid #404040;
+        padding: 8px 20px;
+        color: #cccccc;
+        font-size: 14px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
     }
 
     .viewport {
-        background: #000;
+        flex: 1;
         position: relative;
-        border: 2px solid transparent;
-        transition: border-color 0.3s ease;
-        cursor: crosshair;
         overflow: hidden;
-    }
-
-    .viewport.active {
-        border-color: var(--accent-color);
+        cursor: crosshair;
     }
 
     .viewport canvas {
         width: 100%;
         height: 100%;
         object-fit: contain;
-        transition: transform 0.3s ease;
     }
 
-    .viewport-info {
+    /* Overlay information */
+    .viewport-overlay {
         position: absolute;
-        top: 8px;
-        left: 8px;
-        background: rgba(0, 0, 0, 0.7);
+        pointer-events: none;
+        z-index: 10;
+    }
+
+    .overlay-info {
+        background: rgba(0, 0, 0, 0.8);
         color: white;
-        padding: 4px 8px;
-        border-radius: 4px;
-        font-size: 0.8rem;
-        font-family: monospace;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-size: 12px;
+        font-weight: 600;
+        font-family: 'Consolas', 'Monaco', monospace;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        backdrop-filter: blur(4px);
     }
 
-    .viewport-controls {
-        position: absolute;
-        bottom: 8px;
-        right: 8px;
+    .top-left {
+        top: 12px;
+        left: 12px;
+    }
+
+    .top-right {
+        top: 12px;
+        right: 12px;
+        background: rgba(0, 120, 212, 0.9);
+    }
+
+    .bottom-left {
+        bottom: 12px;
+        left: 12px;
+    }
+
+    .bottom-right {
+        bottom: 12px;
+        right: 12px;
+    }
+
+    /* Right panel */
+    .right-panel {
+        background: #2a2a2a;
+        border-left: 1px solid #404040;
+        width: 300px;
+        overflow-y: auto;
         display: flex;
-        gap: 4px;
+        flex-direction: column;
     }
 
-    .viewport-btn {
-        background: rgba(0, 0, 0, 0.7);
-        border: 1px solid rgba(255, 255, 255, 0.3);
-        color: white;
-        padding: 4px 8px;
-        border-radius: 4px;
-        font-size: 0.7rem;
+    .panel-section {
+        padding: 20px;
+        border-bottom: 1px solid #404040;
+    }
+
+    .panel-section:last-child {
+        border-bottom: none;
+    }
+
+    .section-title {
+        color: #ffffff;
+        font-size: 14px;
+        font-weight: 600;
+        margin-bottom: 16px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+
+    .control-group {
+        margin-bottom: 16px;
+    }
+
+    .control-label {
+        color: #cccccc;
+        font-size: 12px;
+        margin-bottom: 6px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .control-value {
+        color: #ffffff;
+        font-weight: 600;
+        font-family: 'Consolas', 'Monaco', monospace;
+    }
+
+    .slider-container {
+        position: relative;
+        margin: 8px 0;
+    }
+
+    .custom-slider {
+        -webkit-appearance: none;
+        width: 100%;
+        height: 6px;
+        border-radius: 3px;
+        background: #404040;
+        outline: none;
         cursor: pointer;
-        transition: all 0.3s ease;
     }
 
-    .viewport-btn:hover {
-        background: var(--accent-color);
-        border-color: var(--accent-color);
+    .custom-slider::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: #0078d4;
+        cursor: pointer;
+        border: 2px solid #ffffff;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    }
+
+    .custom-slider::-moz-range-thumb {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: #0078d4;
+        cursor: pointer;
+        border: 2px solid #ffffff;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    }
+
+    .preset-buttons {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+        margin-top: 12px;
+    }
+
+    .preset-btn {
+        background: #404040;
+        border: 1px solid #555555;
+        border-radius: 6px;
+        color: #ffffff;
+        padding: 8px 12px;
+        font-size: 11px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        text-align: center;
+    }
+
+    .preset-btn:hover {
+        background: #4a4a4a;
+        border-color: #0078d4;
+    }
+
+    .preset-btn.active {
+        background: #0078d4;
+        border-color: #0078d4;
+    }
+
+    .nav-controls {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+    }
+
+    .nav-btn {
+        background: #404040;
+        border: 1px solid #555555;
+        border-radius: 6px;
+        color: #ffffff;
+        padding: 8px 12px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        flex: 1;
+        text-align: center;
+        font-size: 12px;
+    }
+
+    .nav-btn:hover {
+        background: #4a4a4a;
+        border-color: #0078d4;
+    }
+
+    .nav-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .file-list {
+        max-height: 200px;
+        overflow-y: auto;
+        background: #1f1f1f;
+        border: 1px solid #404040;
+        border-radius: 6px;
+        margin-top: 8px;
+    }
+
+    .file-item {
+        padding: 8px 12px;
+        color: #cccccc;
+        font-size: 12px;
+        cursor: pointer;
+        border-bottom: 1px solid #333333;
+        transition: all 0.2s ease;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .file-item:last-child {
+        border-bottom: none;
+    }
+
+    .file-item:hover {
+        background: #333333;
+        color: #ffffff;
+    }
+
+    .file-item.active {
+        background: #0078d4;
+        color: #ffffff;
+    }
+
+    .file-number {
+        background: #404040;
+        color: #ffffff;
+        padding: 2px 6px;
+        border-radius: 3px;
+        font-size: 10px;
+        font-weight: 600;
     }
 
     .dicom-info {
-        background: var(--card-bg);
-        border: 1px solid var(--border-color);
-        border-radius: 8px;
-        padding: 1rem;
-        margin-bottom: 1rem;
-    }
-
-    .dicom-info h6 {
-        color: var(--accent-color);
-        margin-bottom: 0.5rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        font-size: 0.8rem;
+        background: #1f1f1f;
+        border: 1px solid #404040;
+        border-radius: 6px;
+        padding: 12px;
+        margin-top: 12px;
     }
 
     .dicom-tag {
         display: flex;
         justify-content: space-between;
-        padding: 0.25rem 0;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-        font-size: 0.85rem;
+        align-items: flex-start;
+        padding: 6px 0;
+        border-bottom: 1px solid #333333;
+        font-size: 11px;
     }
 
     .dicom-tag:last-child {
         border-bottom: none;
     }
 
-    .dicom-tag .tag-name {
-        color: var(--text-secondary);
+    .tag-name {
+        color: #cccccc;
         font-weight: 500;
+        min-width: 100px;
     }
 
-    .dicom-tag .tag-value {
-        color: var(--text-primary);
-        font-family: monospace;
+    .tag-value {
+        color: #ffffff;
+        font-family: 'Consolas', 'Monaco', monospace;
+        text-align: right;
         word-break: break-all;
+        max-width: 140px;
     }
 
+    /* File drop overlay */
     .file-drop-overlay {
         position: fixed;
         top: 0;
         left: 0;
         right: 0;
         bottom: 0;
-        background: rgba(0, 0, 0, 0.8);
+        background: rgba(0, 0, 0, 0.9);
         display: none;
         justify-content: center;
         align-items: center;
-        z-index: 1000;
-        backdrop-filter: blur(5px);
+        z-index: 2000;
+        backdrop-filter: blur(8px);
     }
 
     .file-drop-overlay.active {
@@ -233,74 +448,164 @@
     }
 
     .drop-zone {
-        background: var(--card-bg);
-        border: 2px dashed var(--accent-color);
-        border-radius: 16px;
-        padding: 3rem;
+        background: linear-gradient(135deg, #2c2c2c 0%, #1f1f1f 100%);
+        border: 3px dashed #0078d4;
+        border-radius: 20px;
+        padding: 60px 40px;
         text-align: center;
-        max-width: 400px;
+        max-width: 500px;
         width: 90%;
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
     }
 
     .drop-zone-icon {
-        font-size: 4rem;
-        color: var(--accent-color);
-        margin-bottom: 1rem;
+        font-size: 5rem;
+        color: #0078d4;
+        margin-bottom: 20px;
+        animation: bounce 2s infinite;
     }
 
-    .controls-panel {
-        background: var(--card-bg);
-        border-top: 1px solid var(--border-color);
-        padding: 0.5rem 1rem;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
+    @keyframes bounce {
+        0%, 20%, 50%, 80%, 100% {
+            transform: translateY(0);
+        }
+        40% {
+            transform: translateY(-10px);
+        }
+        60% {
+            transform: translateY(-5px);
+        }
     }
 
-    .control-group {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
+    .drop-zone h4 {
+        color: #ffffff;
+        margin-bottom: 12px;
+        font-size: 24px;
+        font-weight: 600;
     }
 
-    .control-btn {
-        background: rgba(14, 165, 233, 0.1);
-        border: 1px solid rgba(14, 165, 233, 0.3);
-        border-radius: 6px;
-        color: var(--accent-color);
-        padding: 6px 12px;
-        font-size: 0.8rem;
-        cursor: pointer;
-        transition: all 0.2s ease;
+    .drop-zone p {
+        color: #cccccc;
+        font-size: 16px;
+        margin: 0;
     }
 
-    .control-btn:hover,
-    .control-btn.active {
-        background: var(--accent-color);
-        color: white;
-    }
-
-    .zoom-info {
-        color: var(--text-secondary);
-        font-size: 0.8rem;
-        font-family: monospace;
-    }
-
+    /* No file message */
     .no-file-message {
         display: flex;
         flex-direction: column;
         justify-content: center;
         align-items: center;
         height: 100%;
-        color: var(--text-secondary);
+        color: #666666;
         text-align: center;
+        background: radial-gradient(circle at center, #1a1a1a 0%, #0f0f0f 100%);
     }
 
     .no-file-icon {
-        font-size: 4rem;
-        margin-bottom: 1rem;
-        color: var(--accent-color);
-        opacity: 0.5;
+        font-size: 6rem;
+        margin-bottom: 24px;
+        color: #0078d4;
+        opacity: 0.6;
+        animation: pulse 3s infinite;
+    }
+
+    @keyframes pulse {
+        0% {
+            opacity: 0.6;
+        }
+        50% {
+            opacity: 0.8;
+        }
+        100% {
+            opacity: 0.6;
+        }
+    }
+
+    .no-file-message h4 {
+        color: #ffffff;
+        margin-bottom: 12px;
+        font-size: 28px;
+        font-weight: 300;
+    }
+
+    .no-file-message p {
+        font-size: 16px;
+        line-height: 1.5;
+        max-width: 400px;
+    }
+
+    /* Scrollbar styling */
+    .right-panel::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    .right-panel::-webkit-scrollbar-track {
+        background: #1f1f1f;
+    }
+
+    .right-panel::-webkit-scrollbar-thumb {
+        background: #404040;
+        border-radius: 4px;
+    }
+
+    .right-panel::-webkit-scrollbar-thumb:hover {
+        background: #4a4a4a;
+    }
+
+    .file-list::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    .file-list::-webkit-scrollbar-track {
+        background: #1f1f1f;
+    }
+
+    .file-list::-webkit-scrollbar-thumb {
+        background: #404040;
+        border-radius: 3px;
+    }
+
+    /* Responsive design */
+    @media (max-width: 1200px) {
+        .right-panel {
+            width: 250px;
+        }
+    }
+
+    @media (max-width: 900px) {
+        .toolbar {
+            width: 60px;
+        }
+        
+        .tool-btn {
+            width: 50px;
+            height: 50px;
+            font-size: 10px;
+        }
+        
+        .tool-btn i {
+            font-size: 16px;
+        }
+        
+        .right-panel {
+            width: 200px;
+        }
+    }
+
+    /* Loading animation */
+    .loading {
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        border: 3px solid rgba(255, 255, 255, 0.3);
+        border-radius: 50%;
+        border-top-color: #0078d4;
+        animation: spin 1s ease-in-out infinite;
+    }
+
+    @keyframes spin {
+        to { transform: rotate(360deg); }
     }
 </style>
 {% endblock %}
@@ -311,107 +616,103 @@
     <div class="viewer-header">
         <div class="viewer-title">
             <i class="fas fa-file-medical"></i>
-            <h3>Standalone DICOM Viewer</h3>
+            <h3>Noctis Pro - Advanced DICOM Viewer</h3>
         </div>
         
         <div class="header-actions">
-            <button class="load-file-btn" onclick="openFileDialog()">
+            <button class="header-btn" onclick="openFileDialog()">
                 <i class="fas fa-folder-open"></i>
                 Load DICOM Files
             </button>
-            <button class="btn btn-success btn-sm" onclick="launchDesktopViewer()" title="Launch Advanced Desktop Viewer">
-                <i class="fas fa-desktop me-1"></i>Desktop Viewer
+            <button class="header-btn secondary" onclick="launchDesktopViewer()" title="Launch Desktop Viewer">
+                <i class="fas fa-desktop"></i>
+                Desktop Viewer
             </button>
-            <button class="btn btn-link text-light" onclick="toggleFullscreen()">
+            <button class="header-btn secondary" onclick="toggleFullscreen()">
                 <i class="fas fa-expand" id="fullscreenIcon"></i>
             </button>
-            <a href="{% url 'worklist:dashboard' %}" class="btn btn-outline-light btn-sm">
-                <i class="fas fa-arrow-left me-1"></i>Back to Dashboard
+            <a href="{% url 'worklist:dashboard' %}" class="header-btn secondary">
+                <i class="fas fa-arrow-left"></i>
+                Dashboard
             </a>
         </div>
     </div>
 
     <!-- Main Content -->
     <div class="viewer-main">
-        <!-- Sidebar -->
-        <div class="sidebar" id="sidebar">
-            <button class="sidebar-toggle" onclick="toggleSidebar()">
-                <i class="fas fa-chevron-left" id="sidebarToggleIcon"></i>
+        <!-- Left Toolbar -->
+        <div class="toolbar">
+            <button class="tool-btn active" data-tool="windowing" onclick="setTool('windowing')">
+                <i class="fas fa-adjust"></i>
+                W/L
             </button>
-            
-            <!-- DICOM Information -->
-            <div class="dicom-info" id="dicomInfo" style="display: none;">
-                <h6>DICOM Information</h6>
-                <div id="dicomTags"></div>
-            </div>
-
-            <!-- File List -->
-            <div class="dicom-info" id="fileList" style="display: none;">
-                <h6>Loaded Files</h6>
-                <div id="fileItems"></div>
-            </div>
-
-            <!-- Instructions -->
-            <div class="dicom-info" id="instructions">
-                <h6>Instructions</h6>
-                <p class="text-secondary" style="font-size: 0.85rem; line-height: 1.4;">
-                    • Click "Load DICOM Files" to browse files<br>
-                    • Drag and drop DICOM files anywhere<br>
-                    • Use mouse wheel to zoom<br>
-                    • Hold Shift + wheel to scroll slices<br>
-                    • Click viewports to activate
-                </p>
-            </div>
+            <button class="tool-btn" data-tool="zoom" onclick="setTool('zoom')">
+                <i class="fas fa-search-plus"></i>
+                Zoom
+            </button>
+            <button class="tool-btn" data-tool="pan" onclick="setTool('pan')">
+                <i class="fas fa-hand-paper"></i>
+                Pan
+            </button>
+            <button class="tool-btn" data-tool="measure" onclick="setTool('measure')">
+                <i class="fas fa-ruler"></i>
+                Measure
+            </button>
+            <button class="tool-btn" data-tool="annotate" onclick="setTool('annotate')">
+                <i class="fas fa-edit"></i>
+                Annotate
+            </button>
+            <button class="tool-btn" data-tool="crosshair" onclick="toggleCrosshair()">
+                <i class="fas fa-crosshairs"></i>
+                Cross
+            </button>
+            <button class="tool-btn" data-tool="invert" onclick="toggleInvert()">
+                <i class="fas fa-adjust"></i>
+                Invert
+            </button>
+            <button class="tool-btn" data-tool="reset" onclick="resetView()">
+                <i class="fas fa-redo"></i>
+                Reset
+            </button>
         </div>
 
-        <!-- Viewer Content -->
-        <div class="viewer-content">
-            <div class="viewport-grid" id="viewportGrid">
-                <!-- Viewport 1 -->
-                <div class="viewport active" id="viewport1" data-viewport="1">
-                    <canvas id="canvas1"></canvas>
-                    <div class="viewport-info" id="info1">
-                        Viewport 1
-                    </div>
-                    <div class="viewport-controls">
-                        <button class="viewport-btn" onclick="resetViewport(1)">Reset</button>
-                        <button class="viewport-btn" onclick="fitToWindow(1)">Fit</button>
+        <!-- Center Viewport -->
+        <div class="viewport-container">
+            <!-- Patient Info Bar -->
+            <div class="patient-info-bar" id="patientInfoBar">
+                <span id="patientInfo">Patient: - | Study Date: - | Modality: -</span>
+                <span id="seriesInfo">Series: - | Images: -</span>
+            </div>
+
+            <!-- Main Viewport -->
+            <div class="viewport" id="mainViewport">
+                <canvas id="dicomCanvas"></canvas>
+                
+                <!-- Overlay Information -->
+                <div class="viewport-overlay top-left">
+                    <div class="overlay-info" id="windowLevelInfo">
+                        WW: 400<br>
+                        WL: 40<br>
+                        Slice: 1/1
                     </div>
                 </div>
-
-                <!-- Viewport 2 -->
-                <div class="viewport" id="viewport2" data-viewport="2">
-                    <canvas id="canvas2"></canvas>
-                    <div class="viewport-info" id="info2">
-                        Viewport 2
-                    </div>
-                    <div class="viewport-controls">
-                        <button class="viewport-btn" onclick="resetViewport(2)">Reset</button>
-                        <button class="viewport-btn" onclick="fitToWindow(2)">Fit</button>
+                
+                <div class="viewport-overlay top-right">
+                    <div class="overlay-info" id="toolInfo">
+                        Tool: Windowing
                     </div>
                 </div>
-
-                <!-- Viewport 3 -->
-                <div class="viewport" id="viewport3" data-viewport="3">
-                    <canvas id="canvas3"></canvas>
-                    <div class="viewport-info" id="info3">
-                        Viewport 3
-                    </div>
-                    <div class="viewport-controls">
-                        <button class="viewport-btn" onclick="resetViewport(3)">Reset</button>
-                        <button class="viewport-btn" onclick="fitToWindow(3)">Fit</button>
+                
+                <div class="viewport-overlay bottom-left">
+                    <div class="overlay-info" id="zoomInfo">
+                        Zoom: 100%
                     </div>
                 </div>
-
-                <!-- Viewport 4 -->
-                <div class="viewport" id="viewport4" data-viewport="4">
-                    <canvas id="canvas4"></canvas>
-                    <div class="viewport-info" id="info4">
-                        Viewport 4
-                    </div>
-                    <div class="viewport-controls">
-                        <button class="viewport-btn" onclick="resetViewport(4)">Reset</button>
-                        <button class="viewport-btn" onclick="fitToWindow(4)">Fit</button>
+                
+                <div class="viewport-overlay bottom-right">
+                    <div class="overlay-info" id="imageInfo">
+                        512 x 512<br>
+                        16 bit
                     </div>
                 </div>
             </div>
@@ -419,42 +720,137 @@
             <!-- No Files Message -->
             <div class="no-file-message" id="noFileMessage">
                 <i class="fas fa-file-medical no-file-icon"></i>
-                <h4 class="text-light">No DICOM Files Loaded</h4>
-                <p>Click "Load DICOM Files" or drag and drop files to start viewing</p>
+                <h4>Advanced DICOM Viewer</h4>
+                <p>Load DICOM files to begin advanced medical image analysis<br>
+                Drag & drop files or click "Load DICOM Files"</p>
+            </div>
+        </div>
+
+        <!-- Right Panel -->
+        <div class="right-panel">
+            <!-- Window/Level Controls -->
+            <div class="panel-section">
+                <h6 class="section-title">Window / Level</h6>
+                
+                <div class="control-group">
+                    <div class="control-label">
+                        <span>Window Width</span>
+                        <span class="control-value" id="windowWidthValue">400</span>
+                    </div>
+                    <div class="slider-container">
+                        <input type="range" class="custom-slider" id="windowWidthSlider" 
+                               min="1" max="4000" value="400" oninput="updateWindowWidth(this.value)">
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <div class="control-label">
+                        <span>Window Level</span>
+                        <span class="control-value" id="windowLevelValue">40</span>
+                    </div>
+                    <div class="slider-container">
+                        <input type="range" class="custom-slider" id="windowLevelSlider" 
+                               min="-1000" max="3000" value="40" oninput="updateWindowLevel(this.value)">
+                    </div>
+                </div>
+                
+                <div class="preset-buttons">
+                    <button class="preset-btn" onclick="setWindowPreset('lung')">Lung</button>
+                    <button class="preset-btn" onclick="setWindowPreset('bone')">Bone</button>
+                    <button class="preset-btn" onclick="setWindowPreset('soft')">Soft</button>
+                    <button class="preset-btn" onclick="setWindowPreset('brain')">Brain</button>
+                    <button class="preset-btn" onclick="setWindowPreset('abdomen')">Abdomen</button>
+                    <button class="preset-btn" onclick="setWindowPreset('mediastinum')">Mediastinum</button>
+                </div>
             </div>
 
-            <!-- Controls Panel -->
-            <div class="controls-panel">
+            <!-- Navigation Controls -->
+            <div class="panel-section">
+                <h6 class="section-title">Navigation</h6>
+                
                 <div class="control-group">
-                    <button class="control-btn active" onclick="setTool('pan')" data-tool="pan">
-                        <i class="fas fa-hand-paper"></i> Pan
+                    <div class="control-label">
+                        <span>Image</span>
+                        <span class="control-value" id="imageIndex">1 / 1</span>
+                    </div>
+                    <div class="nav-controls">
+                        <button class="nav-btn" onclick="previousImage()" id="prevBtn">
+                            <i class="fas fa-step-backward"></i> Prev
+                        </button>
+                        <button class="nav-btn" onclick="nextImage()" id="nextBtn">
+                            <i class="fas fa-step-forward"></i> Next
+                        </button>
+                    </div>
+                </div>
+                
+                <div class="control-group">
+                    <div class="nav-controls">
+                        <button class="nav-btn" onclick="togglePlay()" id="playBtn">
+                            <i class="fas fa-play"></i> Play
+                        </button>
+                        <button class="nav-btn" onclick="resetView()">
+                            <i class="fas fa-redo"></i> Reset
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Transform Controls -->
+            <div class="panel-section">
+                <h6 class="section-title">Transform</h6>
+                
+                <div class="control-group">
+                    <div class="control-label">
+                        <span>Zoom</span>
+                        <span class="control-value" id="zoomValue">100%</span>
+                    </div>
+                    <div class="slider-container">
+                        <input type="range" class="custom-slider" id="zoomSlider" 
+                               min="10" max="1000" value="100" oninput="updateZoom(this.value)">
+                    </div>
+                </div>
+                
+                <div class="nav-controls">
+                    <button class="nav-btn" onclick="fitToWindow()">
+                        <i class="fas fa-expand-arrows-alt"></i> Fit
                     </button>
-                    <button class="control-btn" onclick="setTool('zoom')" data-tool="zoom">
-                        <i class="fas fa-search-plus"></i> Zoom
-                    </button>
-                    <button class="control-btn" onclick="setTool('window')" data-tool="window">
-                        <i class="fas fa-adjust"></i> W/L
-                    </button>
-                    <button class="control-btn" onclick="setTool('measure')" data-tool="measure">
-                        <i class="fas fa-ruler"></i> Measure
+                    <button class="nav-btn" onclick="actualSize()">
+                        <i class="fas fa-compress-arrows-alt"></i> 1:1
                     </button>
                 </div>
+            </div>
 
-                <div class="control-group">
-                    <span class="zoom-info" id="zoomInfo">Zoom: 100%</span>
-                    <span class="zoom-info" id="windowInfo">W/L: Auto</span>
+            <!-- File List -->
+            <div class="panel-section" id="fileListSection" style="display: none;">
+                <h6 class="section-title">Loaded Files</h6>
+                <div class="file-list" id="fileList">
+                    <!-- Files will be populated here -->
                 </div>
+            </div>
 
-                <div class="control-group">
-                    <button class="control-btn" onclick="previousImage()">
-                        <i class="fas fa-step-backward"></i> Prev
-                    </button>
-                    <button class="control-btn" onclick="nextImage()">
-                        <i class="fas fa-step-forward"></i> Next
-                    </button>
-                    <button class="control-btn" onclick="togglePlay()">
-                        <i class="fas fa-play" id="playIcon"></i> Play
-                    </button>
+            <!-- DICOM Information -->
+            <div class="panel-section" id="dicomInfoSection" style="display: none;">
+                <h6 class="section-title">DICOM Information</h6>
+                <div class="dicom-info" id="dicomInfo">
+                    <!-- DICOM tags will be populated here -->
+                </div>
+            </div>
+
+            <!-- Instructions -->
+            <div class="panel-section" id="instructionsSection">
+                <h6 class="section-title">Quick Guide</h6>
+                <div style="color: #cccccc; font-size: 12px; line-height: 1.6;">
+                    <p><strong>Mouse Controls:</strong></p>
+                    <p>• Wheel: Zoom in/out</p>
+                    <p>• Shift + Wheel: Navigate slices</p>
+                    <p>• Left Click + Drag: Pan/Window/Level</p>
+                    <p>• Right Click: Reset view</p>
+                    <br>
+                    <p><strong>Keyboard Shortcuts:</strong></p>
+                    <p>• Arrow Keys: Navigate images</p>
+                    <p>• Space: Play/Pause cine</p>
+                    <p>• R: Reset view</p>
+                    <p>• I: Invert image</p>
                 </div>
             </div>
         </div>
@@ -465,15 +861,15 @@
 <div class="file-drop-overlay" id="fileDropOverlay">
     <div class="drop-zone">
         <i class="fas fa-cloud-upload-alt drop-zone-icon"></i>
-        <h4 class="text-light">Drop DICOM Files Here</h4>
-        <p class="text-secondary">Release to load files</p>
+        <h4>Drop DICOM Files Here</h4>
+        <p>Release to load files into the advanced viewer</p>
     </div>
 </div>
 
 <!-- Hidden File Input -->
 <input type="file" id="fileInput" multiple accept=".dcm,.dicom,application/dicom" style="display: none;">
 
-<!-- CSRF Token for AJAX requests -->
+<!-- CSRF Token -->
 {% csrf_token %}
 {% endblock %}
 
@@ -481,7 +877,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 <script>
 // Global variables
-let currentTool = 'pan';
+let currentTool = 'windowing';
 let currentViewport = 1;
 let loadedFiles = [];
 let dicomData = [];
@@ -491,6 +887,10 @@ let playInterval = null;
 let zoomLevel = 1;
 let panOffset = { x: 0, y: 0 };
 let windowLevel = { width: 400, center: 40 };
+let crosshairEnabled = false;
+let invertEnabled = false;
+let measurements = [];
+let annotations = [];
 
 // CSRF Token utility functions
 function getCookie(name) {
@@ -528,17 +928,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function initializeViewer() {
     // Initialize canvases
-    for (let i = 1; i <= 4; i++) {
-        const canvas = document.getElementById(`canvas${i}`);
-        const ctx = canvas.getContext('2d');
-        resizeCanvas(canvas);
-        
-        // Add click handler for viewport selection
-        document.getElementById(`viewport${i}`).addEventListener('click', () => {
-            setActiveViewport(i);
-        });
-    }
+    const canvas = document.getElementById('dicomCanvas');
+    const ctx = canvas.getContext('2d');
+    resizeCanvas(canvas);
     
+    // Add click handler for viewport selection
+    document.getElementById('mainViewport').addEventListener('click', () => {
+        setActiveViewport(1);
+    });
+
     // Show no file message initially
     showNoFileMessage(true);
 }
@@ -575,51 +973,49 @@ function setupFileHandling() {
 }
 
 function setupViewportInteractions() {
-    for (let i = 1; i <= 4; i++) {
-        const viewport = document.getElementById(`viewport${i}`);
+    const viewport = document.getElementById('mainViewport');
+    
+    viewport.addEventListener('wheel', (e) => {
+        e.preventDefault();
         
-        viewport.addEventListener('wheel', (e) => {
-            e.preventDefault();
+        if (e.shiftKey) {
+            // Scroll through images
+            const delta = e.deltaY > 0 ? 1 : -1;
+            changeImage(delta);
+        } else {
+            // Zoom
+            const delta = e.deltaY > 0 ? 0.9 : 1.1;
+            zoom(delta);
+        }
+    });
+    
+    let isDragging = false;
+    let lastPos = { x: 0, y: 0 };
+    
+    viewport.addEventListener('mousedown', (e) => {
+        if (currentTool === 'pan') {
+            isDragging = true;
+            lastPos = { x: e.clientX, y: e.clientY };
+        }
+    });
+    
+    viewport.addEventListener('mousemove', (e) => {
+        if (isDragging && currentTool === 'pan') {
+            const deltaX = e.clientX - lastPos.x;
+            const deltaY = e.clientY - lastPos.y;
             
-            if (e.shiftKey) {
-                // Scroll through images
-                const delta = e.deltaY > 0 ? 1 : -1;
-                changeImage(delta);
-            } else {
-                // Zoom
-                const delta = e.deltaY > 0 ? 0.9 : 1.1;
-                zoom(delta);
-            }
-        });
-        
-        let isDragging = false;
-        let lastPos = { x: 0, y: 0 };
-        
-        viewport.addEventListener('mousedown', (e) => {
-            if (currentTool === 'pan') {
-                isDragging = true;
-                lastPos = { x: e.clientX, y: e.clientY };
-            }
-        });
-        
-        viewport.addEventListener('mousemove', (e) => {
-            if (isDragging && currentTool === 'pan') {
-                const deltaX = e.clientX - lastPos.x;
-                const deltaY = e.clientY - lastPos.y;
-                
-                panOffset.x += deltaX;
-                panOffset.y += deltaY;
-                
-                updateViewport(currentViewport);
-                
-                lastPos = { x: e.clientX, y: e.clientY };
-            }
-        });
-        
-        viewport.addEventListener('mouseup', () => {
-            isDragging = false;
-        });
-    }
+            panOffset.x += deltaX;
+            panOffset.y += deltaY;
+            
+            updateViewport(currentViewport);
+            
+            lastPos = { x: e.clientX, y: e.clientY };
+        }
+    });
+    
+    viewport.addEventListener('mouseup', () => {
+        isDragging = false;
+    });
 }
 
 function openFileDialog() {
@@ -836,7 +1232,7 @@ function generatePixelData(dicomInfo) {
 function loadImageToViewport(fileIndex, viewportNum) {
     if (!dicomData[fileIndex]) return;
     
-    const canvas = document.getElementById(`canvas${viewportNum}`);
+    const canvas = document.getElementById('dicomCanvas');
     const ctx = canvas.getContext('2d');
     const dicom = dicomData[fileIndex];
     
@@ -862,41 +1258,59 @@ function loadImageToViewport(fileIndex, viewportNum) {
     }
     
     // Update viewport info
-    const info = document.getElementById(`info${viewportNum}`);
-    info.textContent = `${dicom.fileName} (${dicom.width}x${dicom.height})`;
-    
+    const patientInfo = document.getElementById('patientInfo');
+    patientInfo.textContent = `Patient: ${dicom.tags['Patient Name'] || 'N/A'} | Study Date: ${dicom.tags['Study Date'] || 'N/A'} | Modality: ${dicom.tags['Modality'] || 'N/A'}`;
+
+    const seriesInfo = document.getElementById('seriesInfo');
+    seriesInfo.textContent = `Series: ${dicom.tags['Series Description'] || 'N/A'} | Images: ${dicom.tags['Instance Number'] || 'N/A'}`;
+
+    const imageInfo = document.getElementById('imageInfo');
+    imageInfo.innerHTML = `${dicom.width} x ${dicom.height}<br>${dicom.bitsAllocated} bit`;
+
+    const windowLevelInfo = document.getElementById('windowLevelInfo');
+    windowLevelInfo.innerHTML = `WW: ${windowLevel.width}<br>WL: ${windowLevel.center}<br>Slice: ${currentFileIndex + 1}/${dicomData.length}`;
+
+    const toolInfo = document.getElementById('toolInfo');
+    toolInfo.textContent = `Tool: ${currentTool.charAt(0).toUpperCase() + currentTool.slice(1)}`;
+
+    const zoomInfo = document.getElementById('zoomInfo');
+    zoomInfo.textContent = `Zoom: ${Math.round(zoomLevel * 100)}%`;
+
+    const imageIndex = document.getElementById('imageIndex');
+    imageIndex.textContent = `${currentFileIndex + 1} / ${dicomData.length}`;
+
     currentFileIndex = fileIndex;
     updateDicomInfo();
 }
 
 function updateFileList() {
+    const fileListSection = document.getElementById('fileListSection');
     const fileList = document.getElementById('fileList');
-    const fileItems = document.getElementById('fileItems');
     
     if (loadedFiles.length === 0) {
-        fileList.style.display = 'none';
+        fileListSection.style.display = 'none';
         return;
     }
     
-    fileList.style.display = 'block';
-    fileItems.innerHTML = loadedFiles.map((file, index) => `
-        <div class="dicom-tag" style="cursor: pointer;" onclick="loadImageToViewport(${index}, ${currentViewport})">
-            <span class="tag-name">${index + 1}.</span>
-            <span class="tag-value" title="${file.name}">${file.name.length > 20 ? file.name.substring(0, 20) + '...' : file.name}</span>
+    fileListSection.style.display = 'block';
+    fileList.innerHTML = loadedFiles.map((file, index) => `
+        <div class="file-item" onclick="loadImageToViewport(${index}, 1)">
+            <span class="file-number">${index + 1}</span>
+            <span>${file.name}</span>
         </div>
     `).join('');
 }
 
 function updateDicomInfo() {
+    const dicomInfoSection = document.getElementById('dicomInfoSection');
     const dicomInfo = document.getElementById('dicomInfo');
-    const dicomTags = document.getElementById('dicomTags');
     
     if (!dicomData[currentFileIndex]) {
-        dicomInfo.style.display = 'none';
+        dicomInfoSection.style.display = 'none';
         return;
     }
     
-    dicomInfo.style.display = 'block';
+    dicomInfoSection.style.display = 'block';
     const dicom = dicomData[currentFileIndex];
     
     let tagsHtml = '';
@@ -924,38 +1338,38 @@ function updateDicomInfo() {
         </div>
     `;
     
-    dicomTags.innerHTML = tagsHtml;
+    dicomInfo.innerHTML = tagsHtml;
 }
 
 function showNoFileMessage(show) {
     const noFileMessage = document.getElementById('noFileMessage');
-    const viewportGrid = document.getElementById('viewportGrid');
+    const mainViewport = document.getElementById('mainViewport');
     
     if (show) {
         noFileMessage.style.display = 'flex';
-        viewportGrid.style.display = 'none';
+        mainViewport.style.display = 'none';
     } else {
         noFileMessage.style.display = 'none';
-        viewportGrid.style.display = 'grid';
+        mainViewport.style.display = 'block';
     }
 }
 
 function setActiveViewport(viewportNum) {
-    // Remove active class from all viewports
-    for (let i = 1; i <= 4; i++) {
-        document.getElementById(`viewport${i}`).classList.remove('active');
-    }
-    
-    // Add active class to selected viewport
-    document.getElementById(`viewport${viewportNum}`).classList.add('active');
-    currentViewport = viewportNum;
+    // Remove active class from all tool buttons
+    document.querySelectorAll('.tool-btn').forEach(btn => {
+        btn.classList.remove('active');
+    });
+    document.querySelector(`[data-tool="${currentTool}"]`).classList.add('active');
+
+    // Update cursor
+    updateCursor();
 }
 
 function setTool(tool) {
     currentTool = tool;
     
     // Update tool button states
-    document.querySelectorAll('.control-btn').forEach(btn => {
+    document.querySelectorAll('.tool-btn').forEach(btn => {
         btn.classList.remove('active');
     });
     document.querySelector(`[data-tool="${tool}"]`).classList.add('active');
@@ -968,8 +1382,11 @@ function updateCursor() {
     const cursors = {
         pan: 'grab',
         zoom: 'zoom-in',
-        window: 'crosshair',
-        measure: 'crosshair'
+        windowing: 'crosshair',
+        measure: 'crosshair',
+        annotate: 'crosshair',
+        crosshair: 'crosshair',
+        invert: 'crosshair'
     };
     
     document.querySelectorAll('.viewport').forEach(viewport => {
@@ -987,7 +1404,7 @@ function zoom(factor) {
 
 function updateViewport(viewportNum) {
     if (dicomData.length > 0) {
-        loadImageToViewport(currentFileIndex, viewportNum);
+        loadImageToViewport(currentFileIndex, 1);
     }
 }
 
@@ -999,7 +1416,7 @@ function changeImage(delta) {
     if (dicomData.length === 0) return;
     
     currentFileIndex = (currentFileIndex + delta + dicomData.length) % dicomData.length;
-    loadImageToViewport(currentFileIndex, currentViewport);
+    loadImageToViewport(currentFileIndex, 1);
 }
 
 function previousImage() {
@@ -1013,18 +1430,18 @@ function nextImage() {
 function togglePlay() {
     if (dicomData.length < 2) return;
     
-    const playIcon = document.getElementById('playIcon');
+    const playBtn = document.getElementById('playBtn');
     
     if (isPlaying) {
         clearInterval(playInterval);
         isPlaying = false;
-        playIcon.className = 'fas fa-play';
+        playBtn.className = 'fas fa-play';
     } else {
         playInterval = setInterval(() => {
             nextImage();
         }, 500);
         isPlaying = true;
-        playIcon.className = 'fas fa-pause';
+        playBtn.className = 'fas fa-pause';
     }
 }
 
@@ -1038,7 +1455,7 @@ function resetViewport(viewportNum) {
 function fitToWindow(viewportNum) {
     if (!dicomData[currentFileIndex]) return;
     
-    const canvas = document.getElementById(`canvas${viewportNum}`);
+    const canvas = document.getElementById('dicomCanvas');
     const dicom = dicomData[currentFileIndex];
     
     const scaleX = canvas.width / dicom.width;
@@ -1097,9 +1514,11 @@ function launchDesktopViewer() {
 }
 
 function resizeCanvas(canvas) {
-    const rect = canvas.parentElement.getBoundingClientRect();
-    canvas.width = rect.width - 4;
-    canvas.height = rect.height - 4;
+    if (canvas && canvas.parentElement) {
+        const rect = canvas.parentElement.getBoundingClientRect();
+        canvas.width = rect.width - 4;
+        canvas.height = rect.height - 4;
+    }
 }
 
 function formatFileSize(bytes) {
@@ -1129,7 +1548,226 @@ function showNotification(message, type = 'info') {
     }, 5000);
 }
 
-// Initialize cursor
+// Window/Level Presets
+function setWindowPreset(preset) {
+    let newWidth = 400;
+    let newCenter = 40;
+
+    switch (preset) {
+        case 'lung':
+            newWidth = 1500;
+            newCenter = 40;
+            break;
+        case 'bone':
+            newWidth = 2000;
+            newCenter = 60;
+            break;
+        case 'soft':
+            newWidth = 800;
+            newCenter = 40;
+            break;
+        case 'brain':
+            newWidth = 2000;
+            newCenter = 40;
+            break;
+        case 'abdomen':
+            newWidth = 1000;
+            newCenter = 40;
+            break;
+        case 'mediastinum':
+            newWidth = 1000;
+            newCenter = 40;
+            break;
+        default:
+            newWidth = 400;
+            newCenter = 40;
+    }
+
+    updateWindowWidth(newWidth);
+    updateWindowLevel(newCenter);
+}
+
+function updateWindowWidth(value) {
+    windowLevel.width = parseInt(value);
+    document.getElementById('windowWidthValue').textContent = value;
+    updateViewport(1);
+    updateAllOverlays();
+}
+
+function updateWindowLevel(value) {
+    windowLevel.center = parseInt(value);
+    document.getElementById('windowLevelValue').textContent = value;
+    updateViewport(1);
+    updateAllOverlays();
+}
+
+// Transform Controls
+function updateZoom(value) {
+    zoomLevel = parseFloat(value) / 100;
+    document.getElementById('zoomValue').textContent = `${value}%`;
+    updateViewport(1);
+    updateAllOverlays();
+}
+
+function fitToWindow() {
+    if (!dicomData[currentFileIndex]) return;
+    
+    const canvas = document.getElementById('dicomCanvas');
+    const dicom = dicomData[currentFileIndex];
+    
+    const scaleX = canvas.width / dicom.width;
+    const scaleY = canvas.height / dicom.height;
+    zoomLevel = Math.min(scaleX, scaleY) * 0.9;
+    panOffset = { x: 0, y: 0 };
+    
+    updateViewport(1);
+    updateZoomInfo();
+}
+
+function actualSize() {
+    if (!dicomData[currentFileIndex]) return;
+    
+    const canvas = document.getElementById('dicomCanvas');
+    const dicom = dicomData[currentFileIndex];
+    
+    zoomLevel = 1;
+    panOffset = { x: 0, y: 0 };
+    
+    updateViewport(1);
+    updateZoomInfo();
+}
+
+function resetView() {
+    zoomLevel = 1;
+    panOffset = { x: 0, y: 0 };
+    updateViewport(1);
+    updateZoomInfo();
+}
+
+function toggleCrosshair() {
+    crosshairEnabled = !crosshairEnabled;
+    document.getElementById('mainViewport').style.cursor = crosshairEnabled ? 'crosshair' : 'default';
+    document.getElementById('toolInfo').textContent = `Tool: ${currentTool.charAt(0).toUpperCase() + currentTool.slice(1)}`;
+}
+
+function toggleInvert() {
+    invertEnabled = !invertEnabled;
+    updateViewport(1); // Re-apply image to apply inversion
+    document.getElementById('toolInfo').textContent = `Tool: ${currentTool.charAt(0).toUpperCase() + currentTool.slice(1)}`;
+}
+
+// Keyboard shortcuts
+document.addEventListener('keydown', function(e) {
+    switch(e.key) {
+        case 'ArrowLeft':
+            e.preventDefault();
+            previousImage();
+            break;
+        case 'ArrowRight':
+            e.preventDefault();
+            nextImage();
+            break;
+        case ' ':
+            e.preventDefault();
+            togglePlay();
+            break;
+        case 'r':
+        case 'R':
+            e.preventDefault();
+            resetView();
+            break;
+        case 'i':
+        case 'I':
+            e.preventDefault();
+            toggleInvert();
+            break;
+        case 'f':
+        case 'F':
+            e.preventDefault();
+            fitToWindow();
+            break;
+        case '1':
+            e.preventDefault();
+            setTool('windowing');
+            break;
+        case '2':
+            e.preventDefault();
+            setTool('zoom');
+            break;
+        case '3':
+            e.preventDefault();
+            setTool('pan');
+            break;
+        case '4':
+            e.preventDefault();
+            setTool('measure');
+            break;
+        case '5':
+            e.preventDefault();
+            setTool('annotate');
+            break;
+    }
+});
+
+// Window resize handler
+window.addEventListener('resize', function() {
+    const canvas = document.getElementById('dicomCanvas');
+    if (canvas) {
+        resizeCanvas(canvas);
+        updateViewport(1);
+    }
+});
+
+// Improved error handling
+window.addEventListener('error', function(e) {
+    console.error('DICOM Viewer Error:', e.error);
+    showNotification('An error occurred while processing the image', 'error');
+});
+
+// Initialize cursor and setup
 updateCursor();
+
+// Additional utility functions
+function showLoading(show) {
+    const loadBtn = document.querySelector('.header-btn');
+    if (show) {
+        loadBtn.innerHTML = '<div class="loading"></div> Loading...';
+        loadBtn.disabled = true;
+    } else {
+        loadBtn.innerHTML = '<i class="fas fa-folder-open"></i> Load DICOM Files';
+        loadBtn.disabled = false;
+    }
+}
+
+function updateAllOverlays() {
+    if (dicomData.length > 0 && dicomData[currentFileIndex]) {
+        const dicom = dicomData[currentFileIndex];
+        
+        // Update all overlay information
+        document.getElementById('windowLevelInfo').innerHTML = 
+            `WW: ${windowLevel.width}<br>WL: ${windowLevel.center}<br>Slice: ${currentFileIndex + 1}/${dicomData.length}`;
+        
+        document.getElementById('toolInfo').textContent = 
+            `Tool: ${currentTool.charAt(0).toUpperCase() + currentTool.slice(1)}`;
+        
+        document.getElementById('zoomInfo').textContent = 
+            `Zoom: ${Math.round(zoomLevel * 100)}%`;
+        
+        document.getElementById('imageInfo').innerHTML = 
+            `${dicom.width} x ${dicom.height}<br>${dicom.bitsAllocated} bit`;
+        
+        // Update sliders
+        document.getElementById('windowWidthSlider').value = windowLevel.width;
+        document.getElementById('windowLevelSlider').value = windowLevel.center;
+        document.getElementById('zoomSlider').value = Math.round(zoomLevel * 100);
+        
+        // Update values
+        document.getElementById('windowWidthValue').textContent = windowLevel.width;
+        document.getElementById('windowLevelValue').textContent = windowLevel.center;
+        document.getElementById('zoomValue').textContent = `${Math.round(zoomLevel * 100)}%`;
+    }
+}
+
+console.log('Advanced DICOM Viewer initialized successfully');
 </script>
 {% endblock %}


### PR DESCRIPTION
Implement a complete redesign of the standalone DICOM viewer to match the PyQt5 desktop viewer's professional appearance and advanced features.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ecd51f4-cd50-45a4-bd87-7921be3f755d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ecd51f4-cd50-45a4-bd87-7921be3f755d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

