### PR TITLE
Debug dicom viewer flickering and server errors

### DIFF
--- a/templates/dicom_viewer/base.html
+++ b/templates/dicom_viewer/base.html
@@ -40,6 +40,15 @@
     #threeMount { position: absolute; inset: 0; }
     #close3d { position: absolute; top: 12px; right: 12px; z-index: 1001; }
   </style>
+  
+  <!-- Import map to resolve bare specifier used by OrbitControls -->
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.160.0/build/three.module.js"
+    }
+  }
+  </script>
 </head>
 <body>
   <div class="layout">
@@ -143,13 +152,8 @@
   </div>
 
   <!-- Three.js for rotatable bone mesh (loaded only if used) -->
-  <script type="module">
-    import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-    import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
-    // Expose as globals for existing viewer code that references window.THREE and THREE.OrbitControls
-    window.THREE = THREE;
-    THREE.OrbitControls = OrbitControls;
-  </script>
+  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+  <script src="https://unpkg.com/three@0.160.0/examples/js/controls/OrbitControls.js"></script>
   <div id="threeContainer">
     <button id="close3d" class="btn">Close 3D</button>
     <div id="threeMount"></div>
@@ -197,6 +201,7 @@
     // MPR plane browsing state
     let mprScroll = { axial: 0, sagittal: 0, coronal: 0, counts: { axial: 0, sagittal: 0, coronal: 0 } };
     let showHuProbe = false;
+    let huEllipse = null;
     let activeTool = 'window';
     let isDragging = false;
     let dragStart = null;


### PR DESCRIPTION
Fixes DICOM viewer flickering and 500 errors by correcting three.js imports and making the image display API more robust to pixel decoding failures.

The `TypeError` for `three` occurred because the browser's module resolution for bare specifiers was not configured, leading to a failure to load the library. The 500 error from the image display API was caused by certain DICOM files failing pixel decoding, which previously resulted in a server error instead of returning partial metadata. This change ensures the API provides essential information even if pixel data is problematic, preventing the frontend from crashing. Additionally, `huEllipse` was declared to prevent a `ReferenceError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b864f4c4-e03a-4428-b975-2aa6508cd6ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b864f4c4-e03a-4428-b975-2aa6508cd6ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

