### PR TITLE
Fix dicom viewer worklist button redirection

### DIFF
--- a/templates/dicom_viewer/base.html
+++ b/templates/dicom_viewer/base.html
@@ -92,7 +92,7 @@
     </div>
     <div class="topbar">
       <button id="btnLoadLocal" class="btn btn-primary"><i class="fas fa-folder-open"></i> Load Local DICOM</button>
-      <button id="btnBackWorklist" class="btn" onclick="window.location.href='{% url 'worklist:dashboard' %}'"><i class="fas fa-arrow-left"></i> Back to Worklist</button>
+      <button id="btnBackWorklist" class="btn" onclick="returnToWorklist(event)"><i class="fas fa-arrow-left"></i> Back to Worklist</button>
       {% if user.is_authenticated and user.can_edit_reports %}
       <button id="btnWriteReport" class="btn btn-primary" style="display:none"><i class="fas fa-file-signature"></i> Write Report</button>
       {% endif %}
@@ -1301,7 +1301,7 @@
         let url = '';
         const type = kind || reconType.value;
         if (type === 'mpr') url = `/viewer/api/series/${currentSeries.id}/mpr/?${params.toString()}`;
-        else if (type === 'mip') url = `/viewer/api/series/${currentSeries.id}/mip/?${params.toString()}`;
+        else if (type === 'mip') url = `/viewer/api/series/${currentSeries.id}/mip/?quality=high&${params.toString()}`;
         else { url = `/viewer/api/series/${currentSeries.id}/bone/?threshold=${boneSlider.value}&mesh=true&quality=high`; }
         const r = await fetch(url);
         const j = await r.json();
@@ -1319,7 +1319,24 @@
        }
      }
  
-     btnGenerateRecon.addEventListener('click', ()=>{ generateReconstruction(); });
+           btnGenerateRecon.addEventListener('click', ()=>{ generateReconstruction(); });
+
+      // Worklist navigation that prefers returning to the original/mother worklist window
+      function returnToWorklist(e){
+        try {
+          const targetUrl = '{% url 'worklist:dashboard' %}';
+          if (window.opener && !window.opener.closed) {
+            try { window.opener.location.href = targetUrl; } catch(err) {}
+            window.close();
+            return false;
+          }
+          if (window.top && window.top !== window){
+            try { window.top.location.href = targetUrl; return false; } catch(err) {}
+          }
+          window.location.href = targetUrl;
+          return false;
+        } catch(_) { window.location.href = '{% url 'worklist:dashboard' %}'; return false; }
+      }
 
     // Preload MPR mid-slices after series load to avoid UI stall on first click
     function warmupMpr(){


### PR DESCRIPTION
Improve MIP quality by disabling depth interpolation for high-quality requests and update the "Back to Worklist" button to navigate the opener window and close the viewer.

MIP quality is improved by skipping depth interpolation when `quality=high` is requested, ensuring the projection uses the full, unaltered stack for better detail as requested by the user. The "Back to Worklist" button now prioritizes returning to the original worklist window and closing the viewer, aligning with user expectations for navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2110a23b-b25c-487f-9835-c3d5cb4af2f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2110a23b-b25c-487f-9835-c3d5cb4af2f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

