### PR TITLE
Fix admin login redirect to worklist

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -42,11 +42,13 @@ def login_view(request):
                         user_agent=user_agent
                     )
                     
-                    # Redirect based on user role
-                    if user.is_admin():
-                        return redirect('admin_panel:dashboard')
-                    else:
-                        return redirect('worklist:dashboard')
+                    # Honor "next" parameter if present and looks like an internal path
+                    next_url = request.GET.get('next') or request.POST.get('next')
+                    if next_url and isinstance(next_url, str) and next_url.startswith('/'):
+                        return redirect(next_url)
+                    
+                    # Redirect all users to worklist dashboard by default
+                    return redirect('worklist:dashboard')
                 else:
                     messages.error(request, 'Account is disabled. Please contact administrator.')
             else:

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -234,7 +234,7 @@
 {% endblock %}
 
 {% block content %}
-{% with True as hide_navbar %}
+{% with hide_footer=True %}
 <div class="login-container">
     <div class="login-card fade-in">
         <div class="logo-container">
@@ -261,6 +261,9 @@
 
         <form method="post" id="loginForm">
             {% csrf_token %}
+            {% if request.GET.next %}
+            <input type="hidden" name="next" value="{{ request.GET.next }}" />
+            {% endif %}
             <div class="form-floating">
                 <input type="text" class="form-control" id="username" name="username" 
                        placeholder="Username" required autocomplete="username">


### PR DESCRIPTION
Redirects all users, including admins, to the worklist after login and ensures the `next` parameter is respected.

---
<a href="https://cursor.com/background-agent?bcId=bc-151c89f7-25c2-4bd4-8474-42839a426e21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-151c89f7-25c2-4bd4-8474-42839a426e21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

