### PR TITLE
Enable system auto-start and network access

### DIFF
--- a/ops/install_services.sh
+++ b/ops/install_services.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="/workspace"
+VENV_DIR="$APP_DIR/venv"
+HOST="127.0.0.1"
+PORT="8000"
+
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+	echo "This script must be run with sudo or as root."
+	exit 1
+fi
+
+apt-get update -y
+apt-get install -y python3 python3-venv python3-dev build-essential libpq-dev libjpeg-dev zlib1g-dev libopenjp2-7 libssl-dev libffi-dev git redis-server nginx
+
+systemctl enable --now redis-server || true
+
+if [ ! -d "$VENV_DIR" ]; then
+	python3 -m venv "$VENV_DIR"
+fi
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip wheel setuptools
+pip install -r "$APP_DIR/requirements.txt"
+
+cd "$APP_DIR"
+"$VENV_DIR/bin/python" manage.py migrate --noinput
+"$VENV_DIR/bin/python" manage.py collectstatic --noinput
+
+cp "$APP_DIR/ops/noctis-web.service" /etc/systemd/system/noctis-web.service
+cp "$APP_DIR/ops/noctis-celery.service" /etc/systemd/system/noctis-celery.service
+cp "$APP_DIR/ops/noctis-dicom.service" /etc/systemd/system/noctis-dicom.service
+
+systemctl daemon-reload
+systemctl enable --now noctis-web.service noctis-celery.service noctis-dicom.service
+
+cp "$APP_DIR/ops/nginx-noctis.conf" /etc/nginx/sites-available/noctis
+ln -sf /etc/nginx/sites-available/noctis /etc/nginx/sites-enabled/noctis
+rm -f /etc/nginx/sites-enabled/default
+
+nginx -t
+systemctl restart nginx
+
+# Open firewall (ignore if ufw is not installed)
+ufw allow "Nginx Full" || true
+ufw allow 11112/tcp || true
+
+IP_ADDR=$(hostname -I 2>/dev/null | awk '{print $1}')
+IP_ADDR=${IP_ADDR:-"<server-ip>"}
+
+echo
+echo "Setup complete. Access the system at: http://$IP_ADDR/"
+echo "Admin panel: http://$IP_ADDR/admin-panel/"
+echo "Worklist: http://$IP_ADDR/worklist/"

--- a/ops/nginx-noctis.conf
+++ b/ops/nginx-noctis.conf
@@ -1,0 +1,40 @@
+upstream noctis_backend {
+	server 127.0.0.1:8000;
+	keepalive 32;
+}
+
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+	server_name _;
+
+	client_max_body_size 200M;
+
+	# Static files
+	location /static/ {
+		alias /workspace/staticfiles/;
+		access_log off;
+		expires 30d;
+	}
+
+	# Media uploads
+	location /media/ {
+		alias /workspace/media/;
+		access_log off;
+		expires 30d;
+	}
+
+	# Proxy all other requests to Daphne (ASGI)
+	location / {
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_read_timeout 300s;
+		proxy_send_timeout 300s;
+		proxy_pass http://noctis_backend;
+	}
+}

--- a/ops/noctis-celery.service
+++ b/ops/noctis-celery.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Noctis Pro Celery Worker
+After=network-online.target redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+WorkingDirectory=/workspace
+Environment=DJANGO_SETTINGS_MODULE=noctis_pro.settings
+Environment=REDIS_URL=redis://127.0.0.1:6379/0
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/workspace/venv/bin/celery -A noctis_pro worker -l info
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/noctis-dicom.service
+++ b/ops/noctis-dicom.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Noctis Pro DICOM Receiver (SCP)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+WorkingDirectory=/workspace
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/workspace/venv/bin/python /workspace/dicom_receiver.py --port 11112 --aet NOCTIS_SCP
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/noctis-web.service
+++ b/ops/noctis-web.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Noctis Pro ASGI (Daphne)
+After=network-online.target redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+WorkingDirectory=/workspace
+Environment=DJANGO_SETTINGS_MODULE=noctis_pro.settings
+Environment=REDIS_URL=redis://127.0.0.1:6379/0
+Environment=PYTHONUNBUFFERED=1
+ExecStartPre=/usr/bin/bash -lc '/workspace/venv/bin/python /workspace/manage.py migrate --noinput'
+ExecStartPre=/usr/bin/bash -lc '/workspace/venv/bin/python /workspace/manage.py collectstatic --noinput'
+ExecStart=/workspace/venv/bin/daphne -b 127.0.0.1 -p 8000 noctis_pro.asgi:application
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add systemd services for the web app, Celery, and DICOM receiver, along with Nginx configuration, to enable auto-start and public access.

---
<a href="https://cursor.com/background-agent?bcId=bc-b25e0114-598a-490f-9eb1-f9cd4f595e57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b25e0114-598a-490f-9eb1-f9cd4f595e57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

