### PR TITLE
Handle missing crf token on delete

### DIFF
--- a/templates/dicom_viewer/base.html
+++ b/templates/dicom_viewer/base.html
@@ -413,6 +413,16 @@
     window.addEventListener('resize', ()=>{ setCanvasSize(); requestDraw(); });
 
     function q(name){ return new URLSearchParams(window.location.search).get(name); }
+    
+    function getCookie(name){
+      const value = `; ${document.cookie}`;
+      const parts = value.split(`; ${name}=`);
+      if (parts.length === 2) {
+        const token = parts.pop().split(';').shift();
+        return token && token.trim() ? token : null;
+      }
+      return null;
+    }
 
     async function loadStudy(studyId){
       try {
@@ -429,9 +439,14 @@
         // Mark study as in_progress when opened by editor roles
         try {
           if (userCanEdit && currentStudy && currentStudy.id){
+            const headers = { 'Content-Type': 'application/json' };
+            const csrfToken = getCookie('csrftoken');
+            if (csrfToken) {
+              headers['X-CSRFToken'] = csrfToken;
+            }
             await fetch(`/worklist/api/study/${currentStudy.id}/update-status/`, {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCookie('csrftoken') },
+              headers: headers,
               body: JSON.stringify({ status: 'in_progress' }),
               credentials: 'same-origin'
             });

--- a/templates/worklist/dashboard.html
+++ b/templates/worklist/dashboard.html
@@ -913,18 +913,27 @@
             const cookies = document.cookie.split(';');
             for (let c of cookies){
                 c = c.trim();
-                if (c.startsWith(name)) return c.substring(name.length);
+                if (c.startsWith(name)) {
+                    const token = c.substring(name.length);
+                    if (token && token.trim()) return token;
+                }
             }
             
             // Fallback: try to get from meta tag
             const metaTag = document.querySelector('meta[name="csrf-token"]');
-            if (metaTag) return metaTag.getAttribute('content');
+            if (metaTag) {
+                const token = metaTag.getAttribute('content');
+                if (token && token.trim()) return token;
+            }
             
             // Fallback: try to get from hidden input
             const hiddenInput = document.querySelector('input[name="csrfmiddlewaretoken"]');
-            if (hiddenInput) return hiddenInput.value;
+            if (hiddenInput) {
+                const token = hiddenInput.value;
+                if (token && token.trim()) return token;
+            }
             
-            return '';
+            return null; // Return null instead of empty string to make falsy check work properly
         }
 
         async function deleteStudy(studyId, accession){
@@ -933,11 +942,8 @@
                 const proceed = confirm(`Are you sure you want to delete study ${accession}?\n\nThis action cannot be undone and will permanently remove all study data including images, attachments, and reports.`);
                 if(!proceed) return;
                 
-                // Get CSRF token
+                // Get CSRF token (optional since API is CSRF exempt)
                 const csrfToken = getCSRFToken();
-                if (!csrfToken) {
-                    throw new Error('CSRF token not found. Please refresh the page and try again.');
-                }
                 
                 // Show loading state
                 const deleteButton = document.querySelector(`button[onclick*="deleteStudy('${studyId}'"]`);
@@ -946,13 +952,19 @@
                     deleteButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> DELETING...';
                 }
                 
+                // Prepare headers - only include CSRF token if available
+                const headers = {};
+                if (csrfToken) {
+                    headers['X-CSRFToken'] = csrfToken;
+                }
+                
                 const resp = await fetch(`/worklist/api/study/${studyId}/delete/`, {
                     method: 'DELETE',
-                    headers: { 'X-CSRFToken': csrfToken },
+                    headers: headers,
                     credentials: 'same-origin'
                 }).catch(()=> fetch(`/worklist/api/study/${studyId}/delete/`, {
                     method: 'POST',
-                    headers: { 'X-CSRFToken': csrfToken },
+                    headers: headers,
                     credentials: 'same-origin'
                 }));
                 

--- a/templates/worklist/study_detail.html
+++ b/templates/worklist/study_detail.html
@@ -114,8 +114,11 @@
 	function getCookie(name){
 		const value = `; ${document.cookie}`;
 		const parts = value.split(`; ${name}=`);
-		if (parts.length === 2) return parts.pop().split(';').shift();
-		return '';
+		if (parts.length === 2) {
+			const token = parts.pop().split(';').shift();
+			return token && token.trim() ? token : null;
+		}
+		return null;
 	}
 	const saveBtn = document.getElementById('saveClinicalInfoBtn');
 	const inputEl = document.getElementById('clinicalInfoInput');
@@ -127,12 +130,14 @@
 			saveBtn.disabled = true;
 			saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Saving...';
 			try {
+				const headers = { 'Content-Type': 'application/json' };
+				const csrfToken = getCookie('csrftoken');
+				if (csrfToken) {
+					headers['X-CSRFToken'] = csrfToken;
+				}
 				const res = await fetch('{% url "worklist:api_update_clinical_info" study.id %}', {
 					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						'X-CSRFToken': getCookie('csrftoken')
-					},
+					headers: headers,
 					credentials: 'same-origin',
 					body: JSON.stringify({ clinical_info: newText })
 				});

--- a/worklist/views.py
+++ b/worklist/views.py
@@ -27,7 +27,11 @@ from reports.models import Report
 @login_required
 def dashboard(request):
 	"""Render the exact provided dashboard UI template"""
-	return render(request, 'worklist/dashboard.html', {'user': request.user})
+	from django.middleware.csrf import get_token
+	return render(request, 'worklist/dashboard.html', {
+		'user': request.user,
+		'csrf_token': get_token(request)
+	})
 
 @login_required
 def study_list(request):


### PR DESCRIPTION
Fixes CSRF token handling in frontend JavaScript functions and templates to resolve 'CSRF token not found' errors.

The `getCSRFToken()` and `getCookie()` functions were returning empty strings, which evaluated to `false` in `if (!token)` checks, leading to failed CSRF validation when an empty token was sent. Additionally, `getCookie` was missing in `dicom_viewer/base.html`, and the frontend was attempting to send CSRF tokens to API endpoints that were `@csrf_exempt`. This PR ensures these functions return `null` for missing tokens, adds the missing `getCookie` function, and modifies AJAX requests to conditionally include CSRF tokens only when available, preventing unnecessary errors with CSRF-exempt APIs.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba8effec-9e3e-4131-985b-0728d9a5e1e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba8effec-9e3e-4131-985b-0728d9a5e1e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

