### PR TITLE
Sed substitution error at character 30

### DIFF
--- a/ops/install_services.sh
+++ b/ops/install_services.sh
@@ -210,8 +210,8 @@ if [ -n "$DUCK_DOMAIN" ]; then
 	SERVER_NAMES="$SERVER_NAMES $DUCK_DOMAIN"
 fi
 NGINX_SITE="/etc/nginx/sites-available/noctis"
-sed -e "s|{{SERVER_NAME}}|$SERVER_NAMES|g" \
-	-e "s|{{APP_DIR}}|$APP_DIR|g" \
+sed -e "s#{{SERVER_NAME}}#$SERVER_NAMES#g" \
+	-e "s#{{APP_DIR}}#$APP_DIR#g" \
 	"$APP_DIR/ops/nginx-noctis.conf.template" > "$NGINX_SITE"
 ln -sf "$NGINX_SITE" /etc/nginx/sites-enabled/noctis
 rm -f /etc/nginx/sites-enabled/default

--- a/quick_deployment_script.sh
+++ b/quick_deployment_script.sh
@@ -107,10 +107,10 @@ echo "System configuration completed!"
 EOF
 
 # Replace placeholders in the configuration script
-sed -i "s/TIMEZONE_PLACEHOLDER/$TIMEZONE/g" /tmp/configure_system.sh
-sed -i "s/HOSTNAME_PLACEHOLDER/$HOSTNAME/g" /tmp/configure_system.sh
-sed -i "s/USERNAME_PLACEHOLDER/$USERNAME/g" /tmp/configure_system.sh
-sed -i "s|DISK_PLACEHOLDER|${TARGET_PARTITION%?}|g" /tmp/configure_system.sh  # Remove last character (partition number)
+sed -i "s#TIMEZONE_PLACEHOLDER#$TIMEZONE#g" /tmp/configure_system.sh
+sed -i "s#HOSTNAME_PLACEHOLDER#$HOSTNAME#g" /tmp/configure_system.sh
+sed -i "s#USERNAME_PLACEHOLDER#$USERNAME#g" /tmp/configure_system.sh
+sed -i "s#DISK_PLACEHOLDER#${TARGET_PARTITION%?}#g" /tmp/configure_system.sh  # Remove last character (partition number)
 
 # Copy script to chroot environment and make executable
 sudo cp /tmp/configure_system.sh $TARGET_MOUNT/tmp/configure_system.sh


### PR DESCRIPTION
Change `sed` delimiters from `|` or `/` to `#` to prevent syntax errors when variables contain special characters.

The original `sed` commands failed with "unknown s etc" errors because variables like `SERVER_NAMES` or `TARGET_PARTITION` could contain characters (like `|` or `/`) that were also used as `sed` delimiters, leading to malformed expressions. Switching to `#` as a delimiter avoids these conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc30a288-809f-4191-ace8-c8683ec5eea0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc30a288-809f-4191-ace8-c8683ec5eea0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

