### PR TITLE
Fix sed command syntax error

### DIFF
--- a/deploy_noctis_production.sh
+++ b/deploy_noctis_production.sh
@@ -286,7 +286,7 @@ systemctl restart postgresql
 
 # Configure Redis
 log_info "Configuring Redis..."
-sed -i "s/# requirepass foobared/requirepass $REDIS_PASSWORD/" /etc/redis/redis.conf
+sed -i "s|# requirepass foobared|requirepass $REDIS_PASSWORD|" /etc/redis/redis.conf
 sed -i "s/bind 127.0.0.1 ::1/bind 127.0.0.1/" /etc/redis/redis.conf
 systemctl enable redis-server
 systemctl restart redis-server

--- a/one-line-deploy.sh
+++ b/one-line-deploy.sh
@@ -103,8 +103,8 @@ volumes:
   db_data:
 EOF
 
-# Replace the secret key
-sed -i "s/your-secret-key-here/$SECRET_KEY/g" docker-compose.instant.yml
+# Replace the secret key (using # as delimiter to avoid issues with base64 / characters)
+sed -i "s#your-secret-key-here#$SECRET_KEY#g" docker-compose.instant.yml
 
 success "Application configured"
 

--- a/scripts/complete-desktop-setup.sh
+++ b/scripts/complete-desktop-setup.sh
@@ -179,7 +179,7 @@ setup_noctis() {
             SECRET_KEY=$(openssl rand -base64 32 2>/dev/null || python3 -c "import secrets; print(secrets.token_urlsafe(32))" 2>/dev/null || echo "dev-secret-key-$(date +%s)")
             
             # Replace the default secret key
-            sed -i "s/dev-secret-key-change-before-production-use/$SECRET_KEY/" .env
+            sed -i "s#dev-secret-key-change-before-production-use#$SECRET_KEY#" .env
             log "Environment file created with random secret key"
         else
             error "Environment template not found: .env.desktop.example"

--- a/scripts/quick-start-desktop.sh
+++ b/scripts/quick-start-desktop.sh
@@ -117,7 +117,7 @@ setup_environment() {
             
             # Replace the default secret key
             if command -v sed &> /dev/null; then
-                sed -i "s/dev-secret-key-change-before-production-use/$SECRET_KEY/" "$ENV_FILE"
+                sed -i "s#dev-secret-key-change-before-production-use#$SECRET_KEY#" "$ENV_FILE"
                 log "Generated random secret key"
             fi
             

--- a/scripts/super-simple-start.sh
+++ b/scripts/super-simple-start.sh
@@ -153,7 +153,7 @@ create_environment_simple() {
             fi
             
             # Replace the secret key
-            sed -i "s/dev-secret-key-change-before-production-use/$SECRET_KEY/" "$ENV_FILE"
+            sed -i "s#dev-secret-key-change-before-production-use#$SECRET_KEY#" "$ENV_FILE"
             
             log "Configuration file created with secure settings!"
         else


### PR DESCRIPTION
Fix sed "unterminated 'S' command" errors by changing delimiters.

The error occurred because base64-encoded strings (e.g., `SECRET_KEY`, `REDIS_PASSWORD`) containing forward slashes were used in `sed` commands that also used forward slashes as delimiters, breaking the `sed` syntax. Delimiters have been changed to `#` or `|` to resolve this.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c1a2336-2d3f-4ccf-84ba-69809a4ccb89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c1a2336-2d3f-4ccf-84ba-69809a4ccb89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

