### PR TITLE
Fix persistent error

### DIFF
--- a/deploy-server-duckdns.sh
+++ b/deploy-server-duckdns.sh
@@ -211,7 +211,7 @@ http {
 EOF
 
 # Replace domain placeholder
-sed -i "s/DOMAIN_PLACEHOLDER/$DOMAIN_NAME/g" nginx.conf
+sed -i "s#DOMAIN_PLACEHOLDER#$DOMAIN_NAME#g" nginx.conf
 
 # Stop nginx if running
 systemctl stop nginx 2>/dev/null || true

--- a/deploy-server.sh
+++ b/deploy-server.sh
@@ -157,7 +157,7 @@ http {
 EOF
 
 # Replace domain placeholder
-sed -i "s/DOMAIN_PLACEHOLDER/$DOMAIN_NAME/g" nginx.conf
+sed -i "s#DOMAIN_PLACEHOLDER#$DOMAIN_NAME#g" nginx.conf
 
 # Stop nginx if running
 systemctl stop nginx 2>/dev/null || true

--- a/global_access_setup.sh
+++ b/global_access_setup.sh
@@ -381,8 +381,8 @@ setup_standard_deployment() {
     cp deploy_noctis_production.sh deploy_internet_production.sh
     
     # Update configuration for internet deployment
-    sed -i "s/DOMAIN_NAME=\"noctis-server.local\"/DOMAIN_NAME=\"$domain\"/" deploy_internet_production.sh
-    sed -i "s/SERVER_IP=\"192.168.100.15\"/SERVER_IP=\"$PUBLIC_IP\"/" deploy_internet_production.sh
+    sed -i "s#DOMAIN_NAME=\"noctis-server.local\"#DOMAIN_NAME=\"$domain\"#" deploy_internet_production.sh
+    sed -i "s#SERVER_IP=\"192.168.100.15\"#SERVER_IP=\"$PUBLIC_IP\"#" deploy_internet_production.sh
     
     # Add internet security configurations
     cat >> deploy_internet_production.sh << 'EOF'

--- a/setup_secure_access.sh
+++ b/setup_secure_access.sh
@@ -67,10 +67,10 @@ case $ACCESS_METHOD in
         log_info "Updating Nginx configuration for domain: $DOMAIN_NAME"
         
         # Update Django settings
-        sed -i "s/DOMAIN_NAME=noctis-server.local/DOMAIN_NAME=$DOMAIN_NAME/" $PROJECT_DIR/.env
+        sed -i "s#DOMAIN_NAME=noctis-server.local#DOMAIN_NAME=$DOMAIN_NAME#" $PROJECT_DIR/.env
         
         # Update Nginx configuration
-        sed -i "s/server_name .*/server_name $DOMAIN_NAME;/" /etc/nginx/sites-available/noctis-pro
+        sed -i "s#server_name .*#server_name $DOMAIN_NAME;#" /etc/nginx/sites-available/noctis-pro
         
         # Get SSL certificate
         log_info "Obtaining SSL certificate for $DOMAIN_NAME..."
@@ -81,7 +81,7 @@ case $ACCESS_METHOD in
             sed -i 's/ENABLE_SSL=false/ENABLE_SSL=true/' $PROJECT_DIR/.env
             
             # Update allowed hosts
-            sed -i "s/ALLOWED_HOSTS=.*/ALLOWED_HOSTS=$DOMAIN_NAME,localhost,127.0.0.1/" $PROJECT_DIR/.env
+            sed -i "s#ALLOWED_HOSTS=.*#ALLOWED_HOSTS=$DOMAIN_NAME,localhost,127.0.0.1#" $PROJECT_DIR/.env
             
             # Restart services
             systemctl restart noctis-django noctis-daphne nginx
@@ -161,8 +161,8 @@ EOF
         systemctl start wg-quick@wg0
         
         # Update Nginx to only listen on VPN interface
-        sed -i 's/listen 80;/listen 10.0.0.1:80;/' /etc/nginx/sites-available/noctis-pro
-        sed -i 's/listen 443 ssl;/listen 10.0.0.1:443 ssl;/' /etc/nginx/sites-available/noctis-pro
+        sed -i 's#listen 80;#listen 10.0.0.1:80;#' /etc/nginx/sites-available/noctis-pro
+        sed -i 's#listen 443 ssl;#listen 10.0.0.1:443 ssl;#' /etc/nginx/sites-available/noctis-pro
         
         systemctl reload nginx
         
@@ -213,7 +213,7 @@ EOF
         ufw --force enable
         
         # Update Nginx to listen only on private IP
-        sed -i "s/listen 80;/listen 192.168.100.15:80;/" /etc/nginx/sites-available/noctis-pro
+        sed -i "s#listen 80;#listen 192.168.100.15:80;#" /etc/nginx/sites-available/noctis-pro
         
         systemctl reload nginx
         


### PR DESCRIPTION
Update `sed` delimiters in deployment scripts to prevent "unterminated 'S' command" errors.

This change resolves issues where variables like `DOMAIN_NAME`, `PUBLIC_IP`, and `SERVER_IP` could contain forward slashes, conflicting with the default `/` delimiter in `sed` substitution commands. Delimiters have been changed to `#` or `|` in affected scripts to ensure robust variable substitution.

---
<a href="https://cursor.com/background-agent?bcId=bc-89053e57-e33f-4f2f-92a7-d701bf98013e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89053e57-e33f-4f2f-92a7-d701bf98013e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

