### PR TITLE
Start production server with ngrok

### DIFF
--- a/setup_ngrok.sh
+++ b/setup_ngrok.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+echo "🔧 Ngrok Setup Helper"
+echo "===================="
+echo ""
+
+# Check if ngrok is installed
+if ! command -v ngrok &> /dev/null; then
+    echo "❌ Ngrok is not installed. Installing now..."
+    
+    # Install ngrok
+    curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
+    echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list
+    sudo apt update && sudo apt install ngrok
+    
+    if command -v ngrok &> /dev/null; then
+        echo "✅ Ngrok installed successfully"
+    else
+        echo "❌ Failed to install ngrok"
+        exit 1
+    fi
+else
+    echo "✅ Ngrok is already installed"
+fi
+
+echo ""
+
+# Check if ngrok is configured
+if ngrok config check > /dev/null 2>&1; then
+    echo "✅ Ngrok is already configured!"
+    echo ""
+    echo "🌐 You can now run: ./start_with_ngrok.sh"
+else
+    echo "❌ Ngrok is not configured yet"
+    echo ""
+    echo "📋 To configure ngrok:"
+    echo ""
+    echo "1. 🌐 Sign up for a free ngrok account:"
+    echo "   https://dashboard.ngrok.com/signup"
+    echo ""
+    echo "2. 🔑 Get your authtoken:"
+    echo "   https://dashboard.ngrok.com/get-started/your-authtoken"
+    echo ""
+    echo "3. 🛠️  Configure ngrok with your token:"
+    echo "   ngrok config add-authtoken <your-token-here>"
+    echo ""
+    echo "4. 🚀 Then run: ./start_with_ngrok.sh"
+    echo ""
+    
+    # Prompt for token if running interactively
+    if [ -t 0 ]; then
+        echo "💡 If you have your authtoken ready, you can enter it now:"
+        read -p "Enter your ngrok authtoken (or press Enter to skip): " token
+        
+        if [ ! -z "$token" ]; then
+            ngrok config add-authtoken "$token"
+            if ngrok config check > /dev/null 2>&1; then
+                echo "✅ Ngrok configured successfully!"
+                echo "🚀 You can now run: ./start_with_ngrok.sh"
+            else
+                echo "❌ Failed to configure ngrok. Please check your token."
+            fi
+        fi
+    fi
+fi
+
+echo ""
+echo "📖 Alternative access methods:"
+echo "   • Local: http://localhost:8000"
+echo "   • Network: http://$(hostname -I | awk '{print $1}'):8000"
+echo ""


### PR DESCRIPTION
Improve ngrok integration by adding installation, configuration, and robust error handling to the start script.

The original `start_with_ngrok.sh` script failed if ngrok was not installed or configured, leading to a "Could not get ngrok URL" error. This PR introduces a `setup_ngrok.sh` helper script for guided installation and token configuration, and enhances `start_with_ngrok.sh` to check ngrok's status, provide clear setup instructions, and gracefully handle cleanup, ensuring a more user-friendly experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-e17f3e7d-a9fa-4973-991a-c2f300f9a2b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e17f3e7d-a9fa-4973-991a-c2f300f9a2b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

