### PR TITLE
Fix csrf verification failure with ngrok

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,6 @@ SECRET_KEY=django-ngrok-demo-key-12345
 ALLOWED_HOSTS=*
 DB_ENGINE=django.db.backends.sqlite3
 DB_NAME=db.sqlite3
+# CSRF settings for ngrok - disable secure cookies for tunneling
+CSRF_COOKIE_SECURE=False
+SESSION_COOKIE_SECURE=False

--- a/noctis_pro/settings.py
+++ b/noctis_pro/settings.py
@@ -179,6 +179,15 @@ CORS_ALLOWED_ORIGINS = [
 
 CORS_ALLOW_CREDENTIALS = True
 
+# CSRF settings for ngrok support
+CSRF_TRUSTED_ORIGINS = [
+    'https://*.ngrok.io',
+    'https://*.ngrok-free.app',
+    'https://*.ngrok.app',
+    'http://localhost:8000',
+    'http://127.0.0.1:8000',
+]
+
 # Custom user model
 AUTH_USER_MODEL = 'accounts.User'
 
@@ -202,8 +211,8 @@ if not DEBUG:
     SECURE_HSTS_SECONDS = int(os.environ.get('SECURE_HSTS_SECONDS', '31536000'))
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
-    SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'True').lower() == 'true'
+    CSRF_COOKIE_SECURE = os.environ.get('CSRF_COOKIE_SECURE', 'True').lower() == 'true'
     SESSION_COOKIE_HTTPONLY = True
     CSRF_COOKIE_HTTPONLY = True
 

--- a/setup_ngrok_auth.sh
+++ b/setup_ngrok_auth.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+echo "🔧 Ngrok Authentication Setup for NoctisPro"
+echo "============================================"
+echo ""
+
+# Check if ngrok is installed
+if ! command -v ngrok &> /dev/null; then
+    echo "❌ Ngrok is not installed!"
+    echo "   Please install ngrok first by running:"
+    echo "   curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null"
+    echo "   echo 'deb https://ngrok-agent.s3.amazonaws.com buster main' | sudo tee /etc/apt/sources.list.d/ngrok.list"
+    echo "   sudo apt update && sudo apt install ngrok"
+    exit 1
+fi
+
+echo "✅ Ngrok is installed"
+echo ""
+
+# Check if auth token is already configured
+if ngrok config check > /dev/null 2>&1; then
+    echo "✅ Ngrok is already configured with an auth token"
+    echo "   You can start the server with: ./start_with_ngrok.sh"
+    exit 0
+fi
+
+echo "🔑 Ngrok authentication token is required"
+echo ""
+echo "📋 To get your auth token:"
+echo "   1. Visit: https://dashboard.ngrok.com/signup"
+echo "   2. Create a free account"
+echo "   3. Go to: https://dashboard.ngrok.com/get-started/your-authtoken"
+echo "   4. Copy your authtoken"
+echo ""
+
+# Prompt for auth token
+read -p "Enter your ngrok auth token: " AUTH_TOKEN
+
+if [ -z "$AUTH_TOKEN" ]; then
+    echo "❌ No auth token provided. Exiting..."
+    exit 1
+fi
+
+# Configure ngrok
+echo "🔧 Configuring ngrok..."
+ngrok config add-authtoken "$AUTH_TOKEN"
+
+if [ $? -eq 0 ]; then
+    echo "✅ Ngrok configured successfully!"
+    echo ""
+    echo "🚀 You can now start the server with ngrok:"
+    echo "   ./start_with_ngrok.sh"
+else
+    echo "❌ Failed to configure ngrok. Please check your auth token."
+    exit 1
+fi


### PR DESCRIPTION
Fix CSRF verification error when using ngrok by trusting ngrok domains and allowing secure cookie configuration.

The "CSRF verification failed" error occurred because Django's CSRF protection did not recognize the dynamically generated ngrok domains as trusted origins. This PR adds ngrok domains to `CSRF_TRUSTED_ORIGINS` and makes `CSRF_COOKIE_SECURE` and `SESSION_COOKIE_SECURE` configurable via environment variables, disabling them for ngrok usage to ensure proper cookie handling over the tunnel. A helper script `setup_ngrok_auth.sh` is also included to streamline ngrok authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-81110619-f210-4350-9f2b-53ab3c652841">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81110619-f210-4350-9f2b-53ab3c652841">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

