### PR TITLE
Fix dicom viewer image display on view

### DIFF
--- a/templates/dicom_viewer/base.html
+++ b/templates/dicom_viewer/base.html
@@ -579,6 +579,12 @@
           if (hp && hp.suggested && hp.suggested.layout === 'mpr-3plane') { generateReconstruction('mpr'); }
         } catch(e){}
       } catch (e) {
+        // Graceful placeholder first, then fallback
+        try {
+          ctx.fillStyle = '#000'; ctx.fillRect(0,0,canvas.width,canvas.height);
+          ctx.fillStyle = '#666'; ctx.font = '14px monospace'; ctx.textAlign = 'center';
+          ctx.fillText('Image failed to load', canvas.width/2, canvas.height/2);
+        } catch(_e){}
         await fallbackToDesktop();
       }
     }


### PR DESCRIPTION
Add server-side placeholder image generation and client-side error display to prevent DICOM viewer from showing blank screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2a7bd30-329d-40ec-ab6e-3d5998aee5fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2a7bd30-329d-40ec-ab6e-3d5998aee5fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

