### PR TITLE
Setup secure access and auto-start

### DIFF
--- a/install_autostart.sh
+++ b/install_autostart.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-WORKSPACE_DIR="/workspace"
+WORKSPACE_DIR="$(pwd)"
 SERVICE_NAME="noctispro-complete"
 SERVICE_FILE="${SERVICE_NAME}.service"
 


### PR DESCRIPTION
Update `install_autostart.sh` to use the current working directory for service file location.

The script previously hardcoded `WORKSPACE_DIR` to `/workspace`, causing the `noctispro-complete.service` file to not be found if the script was executed from a different directory. Changing it to `$(pwd)` ensures the script correctly locates the service file relative to its execution path.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ab7a63e-742b-441c-944a-56d4d96ff8d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ab7a63e-742b-441c-944a-56d4d96ff8d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

