### PR TITLE
Setup noctispro production environment

### DIFF
--- a/setup_noctispro_production.sh
+++ b/setup_noctispro_production.sh
@@ -134,13 +134,11 @@ $SUDO systemctl start postgresql
 log "Configuring PostgreSQL database..."
 
 # Create database user and database
-$SUDO -u postgres psql -c "SELECT 1 FROM pg_user WHERE usename = 'noctis_user';" | grep -q 1 || \
-    $SUDO -u postgres createuser --createdb --no-createrole --no-superuser noctis_user
+$SUDO -u postgres psql -c "SELECT 1 FROM pg_user WHERE usename = 'noctis_user';" | grep -q 1 || $SUDO -u postgres createuser --createdb --no-createrole --no-superuser noctis_user
 
 $SUDO -u postgres psql -c "ALTER USER noctis_user PASSWORD 'noctis_secure_password_2025';"
 
-$SUDO -u postgres psql -c "SELECT 1 FROM pg_database WHERE datname = 'noctis_pro';" | grep -q 1 || \
-    $SUDO -u postgres createdb -O noctis_user noctis_pro
+$SUDO -u postgres psql -c "SELECT 1 FROM pg_database WHERE datname = 'noctis_pro';" | grep -q 1 || $SUDO -u postgres createdb -O noctis_user noctis_pro
 
 echo "✅ PostgreSQL configured"
 echo ""


### PR DESCRIPTION
Fix PostgreSQL user and database creation commands in `setup_noctispro_production.sh` to resolve "command not found" errors.

The original commands for checking and creating the PostgreSQL user and database were split across multiple lines using backslashes for line continuation. However, the shell was misinterpreting the `-u` flag as a standalone command due to the line breaks, causing the script to fail. This PR combines these commands onto single lines to ensure correct execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-0dded1ab-feb2-4312-9f1a-dd6fde5d0b0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0dded1ab-feb2-4312-9f1a-dd6fde5d0b0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

