### PR TITLE
Fix production start script directory error

### DIFF
--- a/start_production.sh
+++ b/start_production.sh
@@ -29,7 +29,8 @@ print_error() {
 }
 
 # Set working directory
-cd /workspace
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
 print_status "🚀 Starting NoctisPro Production Services..."
 
@@ -72,7 +73,7 @@ nohup gunicorn --bind 0.0.0.0:8000 --workers 3 --timeout 120 \
     noctis_pro.wsgi:application > logs/gunicorn.log 2>&1 &
 
 DJANGO_PID=$!
-echo $DJANGO_PID > /workspace/django.pid
+echo $DJANGO_PID > django.pid
 
 # Wait for Django to start
 print_status "Waiting for Django to start..."
@@ -91,7 +92,7 @@ fi
 print_status "Starting ngrok tunnel..."
 nohup ngrok http 8000 --log stdout > logs/ngrok.log 2>&1 &
 NGROK_PID=$!
-echo $NGROK_PID > /workspace/ngrok.pid
+echo $NGROK_PID > ngrok.pid
 
 # Wait for ngrok to start
 print_status "Waiting for ngrok tunnel to establish..."

--- a/status_production.sh
+++ b/status_production.sh
@@ -25,7 +25,9 @@ print_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
-cd /workspace
+# Set working directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
 echo "========================================"
 echo "       NoctisPro Production Status"

--- a/stop_production.sh
+++ b/stop_production.sh
@@ -21,7 +21,9 @@ print_warning() {
     echo -e "${YELLOW}[WARNING]${NC} $1"
 }
 
-cd /workspace
+# Set working directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
 print_status "🛑 Stopping NoctisPro Production Services..."
 


### PR DESCRIPTION
Update production scripts to dynamically set the working directory and use relative PID file paths to fix "No such file or directory" errors when run from non-`/workspace` locations.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa977b64-aadd-471b-afe8-fe30e51ff299">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa977b64-aadd-471b-afe8-fe30e51ff299">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

