### PR TITLE
Clone repository and handle untracked file

### DIFF
--- a/current_ngrok_url.txt.backup
+++ b/current_ngrok_url.txt.backup
@@ -1,0 +1,1 @@
+https://b23fae45492c.ngrok-free.app


### PR DESCRIPTION
Add `current_ngrok_url.txt.backup` to preserve the local ngrok URL during a `git clone` checkout recovery.

A `git clone` operation failed because an untracked `current_ngrok_url.txt` file would be overwritten. This backup file was created to safely store the existing local URL before running `git restore --source=HEAD :/` to complete the repository checkout.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c95fda5-3e5c-4714-be77-969eb7831f57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c95fda5-3e5c-4714-be77-969eb7831f57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

