### PR TITLE
Deploy noctispro pacs system

### DIFF
--- a/dicom_viewer/views.py
+++ b/dicom_viewer/views.py
@@ -1850,27 +1850,7 @@ def process_dicom_study(study_uid, series_map, rep_ds, user, upload_id):
                 }
             )
     
-            # Return success response
-            return JsonResponse({
-                'success': True,
-                'processed_files': processed_files,
-                'study_id': study_obj.id,
-                'study_name': f"{study_obj.patient.full_name} - {study_obj.study_date.strftime('%Y-%m-%d') if study_obj.study_date else 'Unknown Date'}",
-                'message': f'Successfully loaded {processed_files} DICOM files from directory'
-            })
-            
-        except Exception as e:
-            logger.error(f"Error loading directory {directory_path}: {str(e)}")
-            import traceback
-            logger.error(f"Directory load traceback: {traceback.format_exc()}")
-            return JsonResponse({
-                'success': False,
-                'error': f'Failed to load directory: {str(e)}',
-                'directory_path': directory_path if 'directory_path' in locals() else 'Unknown'
-            }, status=500)
-    
-    # For GET requests, show the directory loader form
-    return render(request, 'dicom_viewer/load_directory.html')
+    return study_obj
 
 @login_required
 @csrf_exempt


### PR DESCRIPTION
Refactor `process_dicom_study` to remove misplaced web response logic and fix a `SyntaxError`.

The `process_dicom_study` helper function incorrectly contained `JsonResponse` and `render` statements, along with an unmatched `except` block, leading to a `SyntaxError`. This change ensures the function correctly returns the `study_obj` and removes the extraneous web response handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b1ad24f-8299-4062-90d3-77be11730111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b1ad24f-8299-4062-90d3-77be11730111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

