### PR TITLE
Fix rollback and permission error

### DIFF
--- a/dicom_receiver.py
+++ b/dicom_receiver.py
@@ -268,12 +268,12 @@ class DicomReceiver:
             'last_received': None
         }
         
-        # Storage directory
-        self.storage_dir = Path('/workspace/media/dicom/received')
+        # Storage directory rooted at project base directory
+        self.storage_dir = BASE_DIR / 'media' / 'dicom' / 'received'
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         
-        # Thumbnail directory
-        self.thumbnail_dir = Path('/workspace/media/dicom/thumbnails')
+        # Thumbnail directory rooted at project base directory
+        self.thumbnail_dir = BASE_DIR / 'media' / 'dicom' / 'thumbnails'
         self.thumbnail_dir.mkdir(parents=True, exist_ok=True)
         
         # Setup logging
@@ -616,7 +616,7 @@ class DicomReceiver:
         """Create DICOM image database record"""
         try:
             # Create relative path for database storage
-            relative_path = str(file_path.relative_to(Path('/workspace/media')))
+            relative_path = str(file_path.relative_to(BASE_DIR / 'media'))
             file_size = file_path.stat().st_size
             
             # Create DICOM image record
@@ -796,8 +796,8 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
     
-    # Create logs directory
-    os.makedirs('/workspace/logs', exist_ok=True)
+    # Ensure logs directory exists under project base directory
+    (BASE_DIR / 'logs').mkdir(parents=True, exist_ok=True)
     
     # Create receiver instance
     receiver = DicomReceiver(port=args.port, aet=args.aet, max_pdu_size=args.max_pdu)


### PR DESCRIPTION
Update DICOM receiver to use `BASE_DIR` for all internal paths, resolving permission errors when creating directories and storing files.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5017559-0385-4215-b8f7-a932b436bea0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5017559-0385-4215-b8f7-a932b436bea0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

