### PR TITLE
Install packages and restart server

### DIFF
--- a/logs/web.log
+++ b/logs/web.log
@@ -1,9 +1,2 @@
-[2025-09-06 22:26:40 +0000] [8899] [INFO] Starting gunicorn 23.0.0
-[2025-09-06 22:26:40 +0000] [8899] [INFO] Listening at: http://0.0.0.0:8000 (8899)
-[2025-09-06 22:26:40 +0000] [8899] [INFO] Using worker: sync
-[2025-09-06 22:26:40 +0000] [8902] [INFO] Booting worker with pid: 8902
-[2025-09-06 22:26:40 +0000] [8903] [INFO] Booting worker with pid: 8903
-[2025-09-06 22:26:40 +0000] [8907] [INFO] Booting worker with pid: 8907
-[2025-09-06 22:26:40 +0000] [8908] [INFO] Booting worker with pid: 8908
-/workspace/ai_analysis/views.py:866: SyntaxWarning: invalid escape sequence '\s'
-  title = re.sub('\s+', ' ', title_raw).strip()
+nohup: ignoring input
+nohup: failed to run command 'gunicorn': No such file or directory


### PR DESCRIPTION
Update `web.log` to reflect a Gunicorn startup failure because the `gunicorn` command was not found.

The `nohup` command executed by the user resulted in `gunicorn: No such file or directory` in the log, indicating that the virtual environment's `PATH` was not correctly applied or inherited for the `nohup` process. This overwrites previous log entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e6b8211-ff8d-42f4-82da-696d52afeed9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e6b8211-ff8d-42f4-82da-696d52afeed9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

