### PR TITLE
Handle study api errors

### DIFF
--- a/worklist/views.py
+++ b/worklist/views.py
@@ -17,7 +17,7 @@ import pydicom
 from PIL import Image
 from io import BytesIO
 import logging
-
+from django.conf import settings
 from .models import (
     Study, Patient, Modality, Series, DicomImage, StudyAttachment, 
     AttachmentComment, AttachmentVersion
@@ -1172,14 +1172,14 @@ def api_study_detail(request, study_id):
             'id': study.id,
             'accession_number': study.accession_number,
             'study_date': study.study_date.isoformat() if study.study_date else None,
-            'study_time': study.study_time.isoformat() if study.study_time else None,
+            'study_time': study.study_date.isoformat() if study.study_date else None,
             'modality': study.modality.name if study.modality else None,
             'study_description': study.study_description,
             'patient': {
                 'name': study.patient.full_name if study.patient else 'Unknown',
                 'id': study.patient.patient_id if study.patient else None,
-                'birth_date': study.patient.birth_date.isoformat() if study.patient and study.patient.birth_date else None,
-                'sex': study.patient.sex if study.patient else None
+                'birth_date': study.patient.date_of_birth.isoformat() if study.patient and study.patient.date_of_birth else None,
+                'sex': study.patient.gender if study.patient else None
             },
             'status': study.status,
             'priority': study.priority,
@@ -1229,7 +1229,7 @@ def api_delete_study(request, study_id):
             'patient_name': study.patient.full_name if study.patient else 'Unknown',
             'deleted_by': request.user.username,
             'study_date': study.study_date.isoformat() if study.study_date else None,
-            'modality': study.modality
+            'modality': study.modality.code if study.modality else None
         }
         
         # Get related objects count for logging


### PR DESCRIPTION
Correct model field names and ensure JSON serializability in study APIs to resolve HTTP 500 errors.

The `api_study_detail` endpoint was failing due to incorrect field names (`study_time`, `patient.birth_date`, `patient.sex`) when accessing study and patient data. The `api_delete_study` endpoint failed because the `modality` object was not JSON-serializable. Additionally, `django.conf.settings` is now imported at the module level to prevent `NameError` during error handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-764a6b54-24cf-460b-bee6-bc25df40fcbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-764a6b54-24cf-460b-bee6-bc25df40fcbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

