### PR TITLE
Debug api delete study error

### DIFF
--- a/noctis_pro/urls.py
+++ b/noctis_pro/urls.py
@@ -20,6 +20,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.shortcuts import redirect
 from django.http import HttpResponse
+import base64
 from worklist import views as worklist_views  # ENABLED
 from django.views.generic.base import RedirectView
 from . import views
@@ -32,8 +33,15 @@ def home_redirect(request):
     return redirect('accounts:login')
 
 def favicon_view(request):
-    """Return an empty response for favicon requests to avoid 404 errors"""
-    return HttpResponse(status=204)  # No content
+    """Serve a minimal PNG favicon to avoid 404s across environments"""
+    # 1x1 transparent PNG
+    png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8zwAAAgEBAHBhFJQAAAAASUVORK5CYII="
+    )
+    png_bytes = base64.b64decode(png_b64)
+    response = HttpResponse(png_bytes, content_type='image/png')
+    response['Cache-Control'] = 'public, max-age=86400'
+    return response
 
 urlpatterns = [
     # Redirect legacy /admin/ to the worklist dashboard to avoid confusion


### PR DESCRIPTION
Refactor study deletion to use Django storage APIs to prevent 500 errors and add a functional favicon route to prevent 404s.

The previous study deletion logic relied on direct filesystem path manipulation (`os.remove`), which caused `NotImplementedError` or similar issues when using non-local storage backends (e.g., S3). The updated code now uses Django's `FileField.delete()` method, which correctly interacts with the configured storage system. Additionally, a missing favicon route resulted in frequent 404 errors; a new view now serves a minimal, cached PNG.

---
<a href="https://cursor.com/background-agent?bcId=bc-07d61960-4dd6-4556-9518-01b7dc156480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07d61960-4dd6-4556-9518-01b7dc156480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

