### PR TITLE
Fix button ripple effect error

### DIFF
--- a/static/js/button-utils.js
+++ b/static/js/button-utils.js
@@ -25,10 +25,10 @@ class ProfessionalButtons {
 
     enhanceButton(button) {
         // Add professional hover and click effects
-        button.addEventListener('mouseenter', this.handleButtonHover);
-        button.addEventListener('mouseleave', this.handleButtonLeave);
-        button.addEventListener('mousedown', this.handleButtonPress);
-        button.addEventListener('mouseup', this.handleButtonRelease);
+        button.addEventListener('mouseenter', this.handleButtonHover.bind(this));
+        button.addEventListener('mouseleave', this.handleButtonLeave.bind(this));
+        button.addEventListener('mousedown', this.handleButtonPress.bind(this));
+        button.addEventListener('mouseup', this.handleButtonRelease.bind(this));
         
         // Add ripple effect capability
         button.style.position = 'relative';


### PR DESCRIPTION
Bind event handlers to fix `TypeError: this.createRipple is not a function`.

The `this` context was lost when event handler methods were passed to `addEventListener`, causing `this.createRipple` to be undefined. Binding the methods ensures `this` correctly refers to the `ProfessionalButtons` instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2c721dd-0e11-480a-b06c-f298cfafe4d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2c721dd-0e11-480a-b06c-f298cfafe4d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

