### PR TITLE
Fix incomplete file upload

### DIFF
--- a/worklist/views.py
+++ b/worklist/views.py
@@ -511,11 +511,6 @@ def upload_study(request):
 									'file_path': saved_path,
 									'file_size': file_size,
 									'processed': False,
-									'window_center': window_center,
-									'window_width': window_width,
-									'acquisition_number': acquisition_number,
-									'temporal_position': temporal_position,
-									'upload_timestamp': timezone.now(),
 								}
 							)
 							


### PR DESCRIPTION
Remove non-existent fields from `DicomImage` creation to fix silent failures during image uploads.

The `DicomImage.objects.get_or_create` call included `window_center`, `window_width`, `acquisition_number`, `temporal_position`, and `upload_timestamp` in its `defaults` dictionary, which are not valid fields on the `DicomImage` model. This caused image creation to fail silently, preventing actual image files from being saved despite their names appearing.

---
<a href="https://cursor.com/background-agent?bcId=bc-26d0b5f6-f876-4884-bd46-2b32f3a3d693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-26d0b5f6-f876-4884-bd46-2b32f3a3d693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

