### PR TITLE
Fix dicom viewer folder loading and display

### DIFF
--- a/static/js/button-utils.js
+++ b/static/js/button-utils.js
@@ -50,12 +50,15 @@ class ProfessionalButtons {
     }
 
     handleButtonPress(e) {
-        if (e.target.disabled) return;
+        const btn = e.currentTarget || e.target;
+        if (btn && btn.disabled) return;
         
-        // Create ripple effect
-        this.createRipple(e);
+        // Create ripple effect (static to avoid context issues)
+        ProfessionalButtons.createRipple(e);
         
-        e.target.style.transform = 'translateY(0)';
+        if (btn) {
+            btn.style.transform = 'translateY(0)';
+        }
     }
 
     handleButtonRelease(e) {
@@ -67,7 +70,7 @@ class ProfessionalButtons {
     }
 
     createRipple(e) {
-        const button = e.target;
+        const button = e.currentTarget || e.target;
         const rect = button.getBoundingClientRect();
         const size = Math.max(rect.width, rect.height);
         const x = e.clientX - rect.left - size / 2;
@@ -92,6 +95,31 @@ class ProfessionalButtons {
         setTimeout(() => {
             ripple.remove();
         }, 600);
+    }
+
+    // Static variant to ensure availability when handler context is altered
+    static createRipple(e) {
+        const button = (e && (e.currentTarget || e.target)) || null;
+        if (!button) return;
+        const rect = button.getBoundingClientRect();
+        const size = Math.max(rect.width, rect.height);
+        const x = e.clientX - rect.left - size / 2;
+        const y = e.clientY - rect.top - size / 2;
+        const ripple = document.createElement('span');
+        ripple.style.cssText = `
+            position: absolute;
+            width: ${size}px;
+            height: ${size}px;
+            left: ${x}px;
+            top: ${y}px;
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            transform: scale(0);
+            animation: ripple 0.6s ease-out;
+            pointer-events: none;
+        `;
+        button.appendChild(ripple);
+        setTimeout(() => ripple.remove(), 600);
     }
 
     setupGlobalEventListeners() {

--- a/worklist/views.py
+++ b/worklist/views.py
@@ -225,19 +225,20 @@ def upload_study(request):
 					sop_uid = getattr(ds, 'SOPInstanceUID', None)
 					modality = getattr(ds, 'Modality', 'OT')
 					
-					# Professional validation with detailed logging
+					# Relaxed validation: synthesize missing UIDs for valid files
 					if not study_uid:
-						logger.warning(f"File {file_index + 1}: Missing StudyInstanceUID")
-						invalid_files += 1
-						continue
+						import uuid as _uuid
+						study_uid = f"SYN-{_uuid.uuid4()}"
+						logger.warning(f"File {file_index + 1}: Missing StudyInstanceUID, synthesized {study_uid}")
 					if not series_uid:
-						logger.warning(f"File {file_index + 1}: Missing SeriesInstanceUID")
-						invalid_files += 1
-						continue
+						import uuid as _uuid
+						series_uid = f"SYN-SER-{_uuid.uuid4()}"
+						logger.warning(f"File {file_index + 1}: Missing SeriesInstanceUID, synthesized {series_uid}")
 					if not sop_uid:
-						logger.warning(f"File {file_index + 1}: Missing SOPInstanceUID")
-						invalid_files += 1
-						continue
+						import uuid as _uuid
+						sop_uid = f"SYN-SOP-{_uuid.uuid4()}"
+						logger.warning(f"File {file_index + 1}: Missing SOPInstanceUID, synthesized {sop_uid}")
+						setattr(ds, 'SOPInstanceUID', sop_uid)
 					
 					# Enhanced series grouping with medical imaging intelligence
 					series_key = f"{series_uid}_{modality}"


### PR DESCRIPTION
Fixes `this.createRipple` error by adjusting button event handling and relaxes DICOM UID validation to prevent "No valid DICOM files found" for valid XR files.

The `this.createRipple` error occurred due to `this` context loss in the event handler; a static method and `e.currentTarget` resolve this. DICOM uploads were failing for files missing `StudyInstanceUID`, `SeriesInstanceUID`, or `SOPInstanceUID` (common in some XR secondary captures), so these UIDs are now synthesized if absent to ensure acceptance.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea2d3231-3bba-4eb2-8fb7-ec7eaeec2226">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea2d3231-3bba-4eb2-8fb7-ec7eaeec2226">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

