### PR TITLE
Enforce admin-only user creation

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -44,6 +44,9 @@ class User(AbstractUser):
         return f"{self.username} ({self.get_role_display()})"
 
     def is_admin(self):
+        # Treat Django superusers and staff as admins for access control
+        if getattr(self, 'is_superuser', False) or getattr(self, 'is_staff', False):
+            return True
         return self.role == 'admin'
 
     def is_radiologist(self):
@@ -56,6 +59,9 @@ class User(AbstractUser):
         return self.role in ['admin', 'radiologist']
 
     def can_manage_users(self):
+        # Allow superusers/staff to manage users, in addition to role-based admin
+        if getattr(self, 'is_superuser', False) or getattr(self, 'is_staff', False):
+            return True
         return self.role == 'admin'
 
 class UserSession(models.Model):


### PR DESCRIPTION
Grant superusers and staff automatic admin and user management privileges.

This resolves issues where superusers lacked full admin capabilities, particularly after a database reset, by ensuring `is_admin` and `can_manage_users` methods correctly reflect their elevated status.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f3d6f72-6b31-454f-a5e8-474ecf7ec765">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f3d6f72-6b31-454f-a5e8-474ecf7ec765">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

