### PR TITLE
Fix upload failures and enable standalone dicom viewing

### DIFF
--- a/templates/dicom_viewer/base.html
+++ b/templates/dicom_viewer/base.html
@@ -2844,13 +2844,16 @@
                 files.forEach(file => {
                     formData.append('dicom_files', file);
                 });
+                formData.append('priority', 'normal');
+                formData.append('clinical_info', 'Uploaded via standalone viewer');
                 
-                const response = await fetch('/dicom-viewer/upload/', {
+                const response = await fetch('/worklist/upload/', {
                     method: 'POST',
                     body: formData,
                     headers: {
                         'X-CSRFToken': getCSRFToken()
-                    }
+                    },
+                    credentials: 'same-origin'
                 });
                 
                 const data = await response.json();

--- a/templates/dicom_viewer/viewer.html
+++ b/templates/dicom_viewer/viewer.html
@@ -1252,7 +1252,7 @@
     </div>
 
     <!-- Hidden file input for DICOM loading -->
-    <input type="file" id="fileInput" accept=".dcm,.dicom,*" multiple style="display: none;">
+    <input type="file" id="fileInput" accept=".dcm,.dicom,*" multiple webkitdirectory directory style="display: none;">
     
     <!-- CSRF Token for AJAX requests -->
     {% csrf_token %}
@@ -1850,11 +1850,13 @@
         function loadFromLocalFiles() {
             try {
                 const fileInput = document.getElementById('fileInput');
-                fileInput.removeAttribute('webkitdirectory');
+                // Allow selecting a folder of DICOMs
+                fileInput.setAttribute('webkitdirectory', '');
+                fileInput.setAttribute('directory', '');
                 fileInput.setAttribute('accept', '.dcm,.dicom,*');
                 fileInput.multiple = true;
                 fileInput.click();
-                showToast('📁 File browser opened - Select DICOM files', 'success');
+                showToast('📁 Select a DICOM folder or files', 'success');
             } catch (e) {
                 showToast('File browser opened', 'success');
             }
@@ -1883,13 +1885,16 @@
                 files.forEach(file => {
                     formData.append('dicom_files', file);
                 });
+                formData.append('priority', 'normal');
+                formData.append('clinical_info', 'Uploaded via standalone viewer');
                 
-                const response = await fetch('/dicom-viewer/upload/', {
+                const response = await fetch('/worklist/upload/', {
                     method: 'POST',
                     body: formData,
                     headers: {
                         'X-CSRFToken': getCSRFToken()
-                    }
+                    },
+                    credentials: 'same-origin'
                 });
                 
                 if (!response.ok) {
@@ -1898,9 +1903,14 @@
                 
                 const data = await response.json();
                 
-                if (data.success && data.study_id) {
-                    await loadStudy(data.study_id);
-                    showToast(`Uploaded ${data.processed_files} files`, 'success');
+                if (data.success) {
+                    const created = Array.isArray(data.created_study_ids) ? data.created_study_ids : [];
+                    if (created.length > 0) {
+                        window.location.href = '/dicom-viewer/?study=' + created[0];
+                    } else if (data.study_id) {
+                        await loadStudy(data.study_id);
+                    }
+                    showToast(`Uploaded ${data.processed_files || files.length} files`, 'success');
                 } else {
                     hideLoading();
                     showToast(data.error || 'Upload failed', 'error');

--- a/templates/dicom_viewer/viewer_complete.html
+++ b/templates/dicom_viewer/viewer_complete.html
@@ -1881,13 +1881,16 @@
                 files.forEach(file => {
                     formData.append('dicom_files', file);
                 });
+                formData.append('priority', 'normal');
+                formData.append('clinical_info', 'Uploaded via standalone viewer');
                 
-                const response = await fetch('/dicom-viewer/upload/', {
+                const response = await fetch('/worklist/upload/', {
                     method: 'POST',
                     body: formData,
                     headers: {
                         'X-CSRFToken': getCSRFToken()
-                    }
+                    },
+                    credentials: 'same-origin'
                 });
                 
                 if (!response.ok) {
@@ -1896,9 +1899,14 @@
                 
                 const data = await response.json();
                 
-                if (data.success && data.study_id) {
-                    await loadStudy(data.study_id);
-                    showToast(`Uploaded ${data.processed_files} files`, 'success');
+                if (data.success) {
+                    const created = Array.isArray(data.created_study_ids) ? data.created_study_ids : [];
+                    if (created.length > 0) {
+                        window.location.href = '/dicom-viewer/?study=' + created[0];
+                    } else if (data.study_id) {
+                        await loadStudy(data.study_id);
+                    }
+                    showToast(`Uploaded ${data.processed_files || files.length} files`, 'success');
                 } else {
                     hideLoading();
                     showToast(data.error || 'Upload failed', 'error');


### PR DESCRIPTION
Fix DICOM upload failures and enable folder-based DICOM loading by correcting upload endpoints and enhancing the local file loader.

The frontend upload logic was incorrectly posting to `/dicom-viewer/upload/`, which caused all uploads from the viewer to fail. This PR updates all viewer-related upload paths to the correct `/worklist/upload/` endpoint and adds support for selecting entire directories of DICOM files, automatically opening the newly created study.

---
<a href="https://cursor.com/background-agent?bcId=bc-97661c04-fbb3-4bd3-91be-0bd5524e2aca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97661c04-fbb3-4bd3-91be-0bd5524e2aca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

