### PR TITLE
Deploy noctispro with docker compose

### DIFF
--- a/deploy-one-command.sh
+++ b/deploy-one-command.sh
@@ -66,6 +66,12 @@ else
   fi
 fi
 
+# Remove conflicting custom network if present (avoids Compose label mismatch)
+if docker network ls --format '{{.Name}}' | grep -q '^noctis_network$'; then
+  echo "🧹 Removing existing network noctis_network to avoid label conflicts..."
+  docker network rm noctis_network || true
+fi
+
 # Deploy with Docker
 echo "🚀 Deploying with Docker..."
 "${DC[@]}" down --remove-orphans 2>/dev/null || true

--- a/docker-compose.yml.bak
+++ b/docker-compose.yml.bak
@@ -1,3 +1,4 @@
+version: '3.8'
 
 services:
   # PostgreSQL Database
@@ -167,3 +168,7 @@ volumes:
     driver: local
   static_files:
     driver: local
+
+networks:
+  default:
+    name: noctis_network


### PR DESCRIPTION
Remove obsolete `version` from `docker-compose.yml` and fix Docker network label conflicts during deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5fcdcb8-2caa-4a22-88d2-129e9bc21010">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5fcdcb8-2caa-4a22-88d2-129e9bc21010">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

