### PR TITLE
Debug noctispro pacs deployment script

### DIFF
--- a/deploy-one-command.sh
+++ b/deploy-one-command.sh
@@ -24,7 +24,7 @@ if [ -f .env ]; then
   . ./.env
   set +a
   # Ensure required vars are set in the current shell; do not rewrite the file
-  : "${SECRET_KEY:=$(python3 -c \"import secrets; print(secrets.token_urlsafe(50))\" 2>/dev/null || echo \"noctis-secret-$(date +%s)\")}"
+  if [ -z "${SECRET_KEY:-}" ]; then SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_urlsafe(50))' 2>/dev/null || echo "noctis-secret-$(date +%s)"); fi
   : "${POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:-}}"
   : "${ADMIN_PASSWORD:=NoctisAdmin2024!}"
 else


### PR DESCRIPTION
Fixes a syntax error in `deploy-one-command.sh` when setting `SECRET_KEY`.

The original parameter expansion for `SECRET_KEY` caused a bash syntax error due to incorrect quoting of the `python3 -c` command. This change uses a standard `if [ -z ... ]` check and correct single quotes for the Python command to safely set the `SECRET_KEY` if it's unset.

---
<a href="https://cursor.com/background-agent?bcId=bc-17d061e6-3ece-47cb-903b-4a78cda46e9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17d061e6-3ece-47cb-903b-4a78cda46e9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

